### PR TITLE
Fix for logic error in adding permissions

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1558,7 +1558,7 @@ namespace DSharpPlus
         internal static Permission InternalAddPermission(Permission before, Permission p)
         {
             Permission after = before;
-            after &= p;
+            after |= p;
             Console.WriteLine(before + " " + after);
             return after;
         }


### PR DESCRIPTION
&= will remove every permission that's not in both sets, so will almost always end up removing all permissions if you're trying to add a single permission that's not already in the destination set.

|= will take everything that's in either or both of the source set and destination set and put it into the destination variable.

This commit changes one instance of &= to |=, in InternalAddPermission().