### PR TITLE
Fixed an issue regarding a NullReferenceException

### DIFF
--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -148,15 +148,15 @@ namespace DSharpPlus.Entities
             if (original.Author != null)
                 this.Author = new EmbedAuthor
                 {
-                    IconUrl = original.Author.IconUrl.ToString(),
+                    IconUrl = original.Author.IconUrl?.ToString(),
                     Name = original.Author.Name,
-                    Url = original.Author.Url.ToString()
+                    Url = original.Author.Url?.ToString()
                 };
 
             if (original.Footer != null)
                 this.Footer = new EmbedFooter
                 {
-                    IconUrl = original.Footer.IconUrl.ToString(),
+                    IconUrl = original.Footer.IconUrl?.ToString(),
                     Text = original.Footer.Text
                 };
 


### PR DESCRIPTION
Using a template with an empty (null) value for Author.Url caused the code to basicly call (null).ToString() which lead to throwing a NullReferenceException.
This can be fixed by using the ?.-operator instead of the normal .-operator before calling ToString(). This way the call will just return null if the input is null and a string if its not.