### PR TITLE
Fix GetGuildBans not returning correct collection

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus
             DefaultMessageNotifications? default_message_notifications, ulong? afk_channel_id, int? afk_timeout, string iconb64, ulong? owner_id, string splashb64, string reason)
             => await ApiClient.ModifyGuildAsync(guild_id, name, region, verification_level, default_message_notifications, afk_channel_id, afk_timeout, iconb64, owner_id, splashb64, reason);
 
-        public async Task<IReadOnlyList<DiscordUser>> GetGuildBansAsync(ulong guild_id) => await ApiClient.GetGuildBansAsync(guild_id);
+        public async Task<IReadOnlyList<DiscordBan>> GetGuildBansAsync(ulong guild_id) => await ApiClient.GetGuildBansAsync(guild_id);
 
         public Task CreateGuildBanAsync(ulong guild_id, ulong user_id, int delete_message_days, string reason) => ApiClient.CreateGuildBanAsync(guild_id, user_id, delete_message_days, reason);
 

--- a/DSharpPlus/Entities/DiscordBan.cs
+++ b/DSharpPlus/Entities/DiscordBan.cs
@@ -1,0 +1,25 @@
+﻿using DSharpPlus.Net.Abstractions;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities
+{
+    /// <summary>
+    /// Represents a Discord ban
+    /// </summary>
+    public class DiscordBan
+    {
+        /// <summary>
+        /// Gets the reason for the ban
+        /// </summary>
+        [JsonProperty("reason", NullValueHandling = NullValueHandling.Ignore)]
+        public string Reason { get; internal set; }
+        
+        /// <summary>
+        /// Gets the banned user
+        /// </summary>
+        [JsonIgnore]
+        public DiscordUser User { get; internal set; }
+        [JsonProperty("user", NullValueHandling = NullValueHandling.Ignore)]
+        internal TransportUser RawUser { get; set; }
+    }
+}

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -322,7 +322,7 @@ namespace DSharpPlus.Entities
         /// Gets the bans for this guild.
         /// </summary>
         /// <returns>Collection of bans in this guild.</returns>
-        public Task<IReadOnlyList<DiscordUser>> GetBansAsync() =>
+        public Task<IReadOnlyList<DiscordBan>> GetBansAsync() =>
             this.Discord.ApiClient.GetGuildBansAsync(Id);
 
         /// <summary>


### PR DESCRIPTION
According to Discord API, [GetGuildBans](https://discordapp.com/developers/docs/resources/guild#get-guild-bans) returns a list of [ban](https://discordapp.com/developers/docs/resources/guild#ban-object) objects.
Also i have tested and it worked.
![proof](https://user-images.githubusercontent.com/23005386/30003170-aaaed6f4-90e3-11e7-9a6f-43b795f1449e.PNG)
