### PR TITLE
Add new property for DiscordEmoji, overload method for WithColor

### DIFF
--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -223,6 +223,20 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Sets the embed's color with specified values for red, green, and blue components, for snowflankes.
+        /// </summary>
+        /// <param name="r">Value of red component.</param>
+        /// <param name="g">Value of green component.</param>
+        /// <param name="b">Value of blue component.</param>
+        /// <returns>This embed builder.</returns>
+        public DiscordEmbedBuilder WithColor(byte r, byte g, byte b)
+        {
+            var color = new DiscordColor(r, g, b);
+            this.Color = color;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the embed's timestamp.
         /// </summary>
         /// <param name="timestamp">Timestamp to set.</param>

--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -223,20 +223,6 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Sets the embed's color with specified values for red, green, and blue components, for snowflankes.
-        /// </summary>
-        /// <param name="r">Value of red component.</param>
-        /// <param name="g">Value of green component.</param>
-        /// <param name="b">Value of blue component.</param>
-        /// <returns>This embed builder.</returns>
-        public DiscordEmbedBuilder WithColor(byte r, byte g, byte b)
-        {
-            var color = new DiscordColor(r, g, b);
-            this.Color = color;
-            return this;
-        }
-
-        /// <summary>
         /// Sets the embed's timestamp.
         /// </summary>
         /// <param name="timestamp">Timestamp to set.</param>

--- a/DSharpPlus/Entities/DiscordEmoji.EmojiUtils.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.EmojiUtils.cs
@@ -7,6 +7,7 @@ namespace DSharpPlus.Entities
     public partial class DiscordEmoji : SnowflakeObject
     {
         private static IReadOnlyDictionary<string, string> UnicodeEmojis { get; set; }
+        private static IReadOnlyDictionary<string, string> DiscordNameLookup { get; set; }
         internal static IReadOnlyList<string> UnicodeEmojiList { get; set; }
 
         static DiscordEmoji()
@@ -1964,6 +1965,8 @@ namespace DSharpPlus.Entities
                 ["X-)"] = "😆"
             };
             UnicodeEmojis = new ReadOnlyDictionary<string, string>(edict);
+            DiscordNameLookup = new ReadOnlyDictionary<string, string>(edict.GroupBy(xkvp => xkvp.Value)
+                .ToDictionary(xg => xg.Key, xg => xg.First().Key));
 
             var el = edict.Values.Distinct().OrderBy(xs => xs);
             UnicodeEmojiList = new ReadOnlyCollection<string>(new List<string>(el));

--- a/DSharpPlus/Entities/DiscordEmoji.EmojiUtils.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.EmojiUtils.cs
@@ -1967,6 +1967,7 @@ namespace DSharpPlus.Entities
 
             var el = edict.Values.Distinct().OrderBy(xs => xs);
             UnicodeEmojiList = new ReadOnlyCollection<string>(new List<string>(el));
+
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordEmoji.EmojiUtils.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.EmojiUtils.cs
@@ -1967,7 +1967,6 @@ namespace DSharpPlus.Entities
 
             var el = edict.Values.Distinct().OrderBy(xs => xs);
             UnicodeEmojiList = new ReadOnlyCollection<string>(new List<string>(el));
-
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -20,7 +20,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the real name of this emoji, not in Unicode format.
         /// </summary>
-        public string RealName { get; internal set; }
+        public string Tag { get; internal set; }
         
         /// <summary>
         /// Gets IDs the roles this emoji is enabled for.
@@ -76,7 +76,7 @@ namespace DSharpPlus.Entities
             if (ReferenceEquals(this, e))
                 return true;
 
-            return this.Id == e.Id && this.Name == e.Name && this.RealName == e.RealName;
+            return this.Id == e.Id && this.Name == e.Name && this.Tag == e.Tag;
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentNullException(nameof(name), "Name cannot be empty or null.");
 
             if (UnicodeEmojis.ContainsKey(name))
-                return new DiscordEmoji { Discord = client, Name = UnicodeEmojis[name], RealName = UnicodeEmojis.Keys.FirstOrDefault(k => k == name) };
+                return new DiscordEmoji { Discord = client, Name = UnicodeEmojis[name], Tag = name };
 
             var ed = client.Guilds.Values.SelectMany(xg => xg.Emojis)
                 .OrderBy(xe => xe.Name)

--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -16,11 +16,6 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
         public string Name { get; internal set; }
-
-        /// <summary>
-        /// Gets the real name of this emoji, not in Unicode format.
-        /// </summary>
-        public string Tag { get; internal set; }
         
         /// <summary>
         /// Gets IDs the roles this emoji is enabled for.
@@ -41,6 +36,19 @@ namespace DSharpPlus.Entities
         public bool Managed { get; internal set; }
 
         internal DiscordEmoji() { }
+
+        /// <summary>
+        /// Gets emoji's name in non-Unicode format (eg. :thinking: instead of the Unicode representation of the emoji).
+        /// </summary>
+        public string GetDiscordName()
+        {
+            DiscordNameLookup.TryGetValue(this.Name, out var name);
+
+            if (name == null)
+                return $":{ this.Name }:";
+
+            return name;
+        }
 
         /// <summary>
         /// Returns a string representation of this emoji.
@@ -76,7 +84,7 @@ namespace DSharpPlus.Entities
             if (ReferenceEquals(this, e))
                 return true;
 
-            return this.Id == e.Id && this.Name == e.Name && this.Tag == e.Tag;
+            return this.Id == e.Id && this.Name == e.Name;
         }
 
         /// <summary>
@@ -194,7 +202,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentNullException(nameof(name), "Name cannot be empty or null.");
 
             if (UnicodeEmojis.ContainsKey(name))
-                return new DiscordEmoji { Discord = client, Name = UnicodeEmojis[name], Tag = name };
+                return new DiscordEmoji { Discord = client, Name = UnicodeEmojis[name] };
 
             var ed = client.Guilds.Values.SelectMany(xg => xg.Emojis)
                 .OrderBy(xe => xe.Name)

--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -18,6 +18,11 @@ namespace DSharpPlus.Entities
         public string Name { get; internal set; }
 
         /// <summary>
+        /// Gets the real name of this emoji, not in Unicode format.
+        /// </summary>
+        public string RealName { get; internal set; }
+        
+        /// <summary>
         /// Gets IDs the roles this emoji is enabled for.
         /// </summary>
         [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
@@ -71,7 +76,7 @@ namespace DSharpPlus.Entities
             if (ReferenceEquals(this, e))
                 return true;
 
-            return this.Id == e.Id && this.Name == e.Name;
+            return this.Id == e.Id && this.Name == e.Name && this.RealName == e.RealName;
         }
 
         /// <summary>
@@ -189,7 +194,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentNullException(nameof(name), "Name cannot be empty or null.");
 
             if (UnicodeEmojis.ContainsKey(name))
-                return new DiscordEmoji { Discord = client, Name = UnicodeEmojis[name] };
+                return new DiscordEmoji { Discord = client, Name = UnicodeEmojis[name], RealName = UnicodeEmojis.Keys.FirstOrDefault(k => k == name) };
 
             var ed = client.Guilds.Values.SelectMany(xg => xg.Emojis)
                 .OrderBy(xe => xe.Name)


### PR DESCRIPTION
Added a color overload method for `DiscordEmbedBuilder` for snowflakes (read: for people wanting some other colors other than the colors from `DiscordColor.Colors`), and `RealName` property which returns the name of the emoji like how it is written in chat (like `:joy:` for example) instead of unicode character, which `Name` returns.