### PR TITLE
Add CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,79 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/DSharpPlus
+    docker:
+      - image: microsoft/dotnet:2.0.0-sdk-2.0.2-jessie
+#      - image: library/mono:5.4.0.201
+    environment:
+      - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    steps:
+      - checkout
+      - run:
+          name: Restore NuGet packages
+          command: dotnet restore -v Minimal
+
+      - run:
+          name: Build DSharpPlus.CommandsNext netstandard1.1
+          command: dotnet build DSharpPlus.CommandsNext -f netstandard1.1 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.CommandsNext netstandard1.3
+          command: dotnet build DSharpPlus.CommandsNext -f netstandard1.3 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.CommandsNext netstandard2.0
+          command: dotnet build DSharpPlus.CommandsNext -f netstandard2.0 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+
+      - run:
+          name: Build DSharpPlus.Interactivity netstandard1.1
+          command: dotnet build DSharpPlus.Interactivity -f netstandard1.1 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.Interactivity netstandard1.3
+          command: dotnet build DSharpPlus.Interactivity -f netstandard1.3 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.Interactivity netstandard2.0
+          command: dotnet build DSharpPlus.Interactivity -f netstandard2.0 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+
+      - run:
+          name: Build DSharpPlus.Rest netstandard1.1
+          command: dotnet build DSharpPlus.Rest -f netstandard1.1 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.Rest netstandard1.3
+          command: dotnet build DSharpPlus.Rest -f netstandard1.3 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.Rest netstandard2.0
+          command: dotnet build DSharpPlus.Rest -f netstandard2.0 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+
+      - run:
+          name: Build DSharpPlus.Test netcoreapp2.0
+          command: dotnet build DSharpPlus.Test -f netcoreapp2.0 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+
+      - run:
+          name: Build DSharpPlus.VoiceNext netstandard1.1
+          command: dotnet build DSharpPlus.VoiceNext -f netstandard1.1 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.VoiceNext netstandard1.3
+          command: dotnet build DSharpPlus.VoiceNext -f netstandard1.3 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.VoiceNext netstandard2.0
+          command: dotnet build DSharpPlus.VoiceNext -f netstandard2.0 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+
+      - run:
+          name: Build DSharpPlus netstandard1.1
+          command: dotnet build DSharpPlus -f netstandard1.1 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus netstandard1.3
+          command: dotnet build DSharpPlus -f netstandard1.3 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus netstandard2.0
+          command: dotnet build DSharpPlus -f netstandard2.0 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+
+      - run:
+          name: Build DSharpPlus.WebSocket.WebSocket4NetCore netstandard1.3
+          command: dotnet build DSharpPlus.WebSocket.WebSocket4NetCore -f netstandard1.3 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+      - run:
+          name: Build DSharpPlus.WebSocket.WebSocket4NetCore netstandard2.0
+          command: dotnet build DSharpPlus.WebSocket.WebSocket4NetCore -f netstandard2.0 -v Minimal -c Release --version-suffix "$CIRCLE_BUILD_NUM"
+
+#      - run:
+#          name: Package
+#          command: dotnet pack DSharpPlus.sln -v Minimal -c Release -o "$dir" --no-build --version-suffix "$CIRCLE_BUILD_NUM"


### PR DESCRIPTION
# Summary
Adds configuration for CircleCI builds. This adds a sensible linux build pipeline (hopefully without the problems Travis caused)

# Details
This is just the configuration, you have to add the project at circleci.com yourself, otherwise the webhooks won't register.

# Changes proposed
* i'm gonna make a sandwich
* i'm gonna put stuff in it
* i'm gonna eat it
* and it will be good

# Notes
* if we added a new build configuration for linux/macos builds we could reduce the mess of 'dotnet build' commands, but that isn't really necessary.
* this will not build the NETFX projects, although this is possible with .NET Core + Mono, it would probably require setting up a new docker image, which isn't really worth the trouble.
* CircleCI build numbers won't match appveyor versions. This is intentional.
* also, remember to add badge to readme afterwards, eg: `https://circleci.com/gh/NaamloosDT/DSharpPlus.svg?&style=shield`