### PR TITLE
change DiscordGuild.GetDefaultChannel to return the first channel the current member can send messages in.

### DIFF
--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -1476,14 +1476,15 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Gets the default channel for this member.
+        /// Gets the default channel for this guild.
+        /// This returns the first channel the current member can send a message in.
         /// </summary>
-        /// <returns>This member's default channel.</returns>
+        /// <returns>This guild's default channel.</returns>
         public DiscordChannel GetDefaultChannel()
         {
             return this._channels.Where(xc => xc.Type == ChannelType.Text)
                 .OrderBy(xc => xc.Position)
-                .FirstOrDefault(xc => (xc.PermissionsFor(this.CurrentMember) & Permissions.AccessChannels) == Permissions.AccessChannels);
+                .FirstOrDefault(xc => (xc.PermissionsFor(this.CurrentMember) & Permissions.SendMessages) == Permissions.SendMessages);
         }
         #endregion
 


### PR DESCRIPTION
# Summary
Changes DiscordGuild.GetDefaultChannel to return the first channel the current member can send messages in, and fixes its xmldocs.

# Details
I think this is a more sensible implementation. There is not much you can do in practice with the current result of GetDefaultChannel.