### PR TITLE
[WIP] Split *.ModifyAsync into smaller methods

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -289,7 +289,7 @@ namespace DSharpPlus.Entities
             if (this.Guild == null)
                 throw new InvalidOperationException("Cannot set parent of non-guild channels.");
                 
-            return this.Discord.ApiClient.ModifyChannelAsync(this.Id, null, null, null, parent, null, null, reason);
+            return this.Discord.ApiClient.ModifyChannelAsync(this.Id, null, null, null, parent.HasValue ? parent.Value?.Id : default(Optional<ulong?>), null, null, reason);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -250,21 +250,80 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Modifies the current channel.
+        /// Renames the current channel.
         /// </summary>
         /// <param name="name">New name for the channel.</param>
-        /// <param name="position">New position for the channel.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns></returns>
+        public Task RenameAsync(string name, string reason = null)
+        {
+            if (this.Guild == null)
+                throw new InvalidOperationException("Cannot rename non-guild channels.");
+                
+            return this.Discord.ApiClient.ModifyChannelAsync(this.Id, name, null, null, default(Optional<ulong?>), null, null, reason);
+        }
+        /// <summary>
+        /// Sets this text channel's topic.
+        /// </summary>
         /// <param name="topic">New topic for the channel.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns></returns>
+        public Task SetTopicAsync(string topic, string reason = null)
+        {
+            if (this.Guild == null)
+                throw new InvalidOperationException("Cannot set topic of non-guild channels.");
+            if (this.Type != ChannelType.Text)
+                throw new InvalidOperationException("Cannot set topic of non-text channels.");
+            
+            return this.Discord.ApiClient.ModifyChannelAsync(this.Id, null, null, topic, default(Optional<ulong?>), null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this channel's parent category.
+        /// </summary>
         /// <param name="parent">Category to put this channel in.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns></returns>
+        public Task SetParentAsync(Optional<DiscordChannel> parent topic, string reason = null)
+        {
+            if (this.Guild == null)
+                throw new InvalidOperationException("Cannot set parent of non-guild channels.");
+                
+            return this.Discord.ApiClient.ModifyChannelAsync(this.Id, null, null, null, parent, null, null, reason);
+        }
+
+        /// <summary>
+        /// Sets this voice channel's bitrate in kbps.
+        /// </summary>
         /// <param name="bitrate">New voice bitrate for the channel.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns></returns>
+        public Task SetBitrateAsync(int bitrate, string reason = null)
+        {
+            if (this.Guild == null)
+                throw new InvalidOperationException("Cannot set user limit of non-guild channels.");
+            if (this.Type != ChannelType.Voice)
+                throw new InvalidOperationException("Cannot set user limit of non-voice channels.");
+                
+            return this.Discord.ApiClient.ModifyChannelAsync(this.Id, null, null, null, default(Optional<ulong?>), bitrate, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this voice channel's connected user limit.
+        /// </summary>
         /// <param name="user_limit">New user limit for the channel.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
-        public Task ModifyAsync(string name = null, int? position = null, string topic = null, Optional<DiscordChannel> parent = default(Optional<DiscordChannel>), int? bitrate = null, 
-            int? user_limit = null, string reason = null)
+        public Task SetUserLimitAsync(int user_limit, string reason = null)
         {
-            return this.Discord.ApiClient.ModifyChannelAsync(this.Id, name, position, topic, parent.HasValue ? parent.Value?.Id : default(Optional<ulong?>), bitrate, user_limit, reason);
+            if (this.Guild == null)
+                throw new InvalidOperationException("Cannot set user limit of non-guild channels.");
+            if (this.Type != ChannelType.Voice)
+                throw new InvalidOperationException("Cannot set user limit of non-voice channels.");
+                
+            return this.Discord.ApiClient.ModifyChannelAsync(this.Id, null, null, null, default(Optional<ulong?>), null, user_limit, reason);
         }
+
 
         /// <summary>
         /// Updates the channel position
@@ -272,7 +331,7 @@ namespace DSharpPlus.Entities
         /// <param name="position"></param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
-        public Task ModifyPositionAsync(int position, string reason = null)
+        public Task MoveAsync(int position, string reason = null)
         {
             if (this.Guild == null)
                 throw new InvalidOperationException("Cannot modify order of non-guild channels.");

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -284,7 +284,7 @@ namespace DSharpPlus.Entities
         /// <param name="parent">Category to put this channel in.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
-        public Task SetParentAsync(Optional<DiscordChannel> parent topic, string reason = null)
+        public Task SetParentAsync(Optional<DiscordChannel> parent, string reason = null)
         {
             if (this.Guild == null)
                 throw new InvalidOperationException("Cannot set parent of non-guild channels.");

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -302,7 +302,7 @@ namespace DSharpPlus.Entities
         /// <param name="name">New name.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> RenameAsync(string name, string reason = null)
+        public async Task<DiscordGuild> RenameAsync(string name, string reason = null)
         {
             return this.Discord.ApiClient.ModifyGuildAsync(this.Id, name, null, null, 
                 null, null, null, null, null, null, null, null, reason);
@@ -314,9 +314,9 @@ namespace DSharpPlus.Entities
         /// <param name="region">New voice region.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetVoiceRegionAsync(DiscordVoiceRegion region, string reason = null)
+        public async Task<DiscordGuild> SetVoiceRegionAsync(DiscordVoiceRegion region, string reason = null)
         {
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, region.Id, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, region.Id, null, 
                 null, null, null, null, null, null, null, null, reason);
         }
         
@@ -326,13 +326,13 @@ namespace DSharpPlus.Entities
         /// <param name="icon">New icon.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetIconAsync(Stream icon, string reason = null)
+        public async Task<DiscordGuild> SetIconAsync(Stream icon, string reason = null)
         {
             string iconb64 = null;
             using (var imgtool = new ImageTool(icon))
                 iconb64 = imgtool.GetBase64();
                     
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, null, null, iconb64, null, null, reason);
         }
         
@@ -342,9 +342,9 @@ namespace DSharpPlus.Entities
         /// <param name="verification_level">New verification level.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetVerificationLevelAsync(VerificationLevel verification_level, string reason = null)
+        public async Task<DiscordGuild> SetVerificationLevelAsync(VerificationLevel verification_level, string reason = null)
         {                    
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, verification_level, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, verification_level, 
                 null, null, null, null, null, null, null, null, reason);
         }
         
@@ -354,9 +354,9 @@ namespace DSharpPlus.Entities
         /// <param name="default_message_notifications">New default notification settings.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetDefaultMessageNotificationsAsync(DefaultMessageNotifications default_message_notifications, string reason = null)
+        public async Task<DiscordGuild> SetDefaultMessageNotificationsAsync(DefaultMessageNotifications default_message_notifications, string reason = null)
         {
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 default_message_notifications, null, null, null, null, null, null, null, reason);
         }
         
@@ -366,9 +366,9 @@ namespace DSharpPlus.Entities
         /// <param name="mfa_level">New MFA requirement setting.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetMfaAsync(MfaLevel mfa_level, string reason = null)
+        public async Task<DiscordGuild> SetMfaAsync(MfaLevel mfa_level, string reason = null)
         {
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, mfa_level, null, null, null, null, null, null, reason);
         }
         
@@ -378,9 +378,9 @@ namespace DSharpPlus.Entities
         /// <param name="explicit_content_filter">New explicit content filter setting.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetExplicitContentFilterAsync(ExplicitContentFilter explicit_content_filter, string reason = null)
+        public async Task<DiscordGuild> SetExplicitContentFilterAsync(ExplicitContentFilter explicit_content_filter, string reason = null)
         {
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, explicit_content_filter, null, null, null, null, null, reason);
         }
         
@@ -390,12 +390,12 @@ namespace DSharpPlus.Entities
         /// <param name="afk_channel">New voice AFK channel.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetAfkChannelAsync(DiscordChannel afk_channel, string reason = null)
+        public async Task<DiscordGuild> SetAfkChannelAsync(DiscordChannel afk_channel, string reason = null)
         {
             if (afk_channel.Type != ChannelType.Voice)
                 throw new ArgumentException("AFK channel needs to be a voice channel.");
 
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, afk_channel.Id, null, null, null, null, reason);
         }
         
@@ -405,9 +405,9 @@ namespace DSharpPlus.Entities
         /// <param name="afk_timeout">New timeout after users are going to be moved to the voice AFK channel in seconds.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetAfkTimeoutAsync(int afk_timeout, string reason = null)
+        public async Task<DiscordGuild> SetAfkTimeoutAsync(int afk_timeout, string reason = null)
         {
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, null, afk_timeout, null, null, null, reason);
         }
         
@@ -417,9 +417,9 @@ namespace DSharpPlus.Entities
         /// <param name="owner">New owner. This can only be changed by current owner.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetOwnerAsync(DiscordMember owner, string reason = null)
+        public async Task<DiscordGuild> SetOwnerAsync(DiscordMember owner, string reason = null)
         {
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, null, null, null, owner.Id, null, reason);
         }
         
@@ -429,13 +429,13 @@ namespace DSharpPlus.Entities
         /// <param name="splash">New invite splash.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public Task<DiscordGuild> SetInviteSplashAsync(DiscordMember owner, string reason = null)
+        public async Task<DiscordGuild> SetInviteSplashAsync(DiscordMember owner, string reason = null)
         {
             string splashb64 = null;
             using (var imgtool = new ImageTool(splash))
                 splashb64 = imgtool.GetBase64();
 
-            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, null, null, null, null, splashb64, reason);
         }
 

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -297,40 +297,146 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.DeleteGuildAsync(this.Id);
 
         /// <summary>
-        /// Modifies this guild.
+        /// Renames this guild.
         /// </summary>
         /// <param name="name">New name.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> RenameAsync(string name, string reason = null)
+        {
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, name, null, null, 
+                null, null, null, null, null, null, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's voice region.
+        /// </summary>
         /// <param name="region">New voice region.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetVoiceRegionAsync(DiscordVoiceRegion region, string reason = null)
+        {
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, region.Id, null, 
+                null, null, null, null, null, null, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's icon.
+        /// </summary>
         /// <param name="icon">New icon.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetIconAsync(Stream icon, string reason = null)
+        {
+            string iconb64 = null;
+            using (var imgtool = new ImageTool(icon))
+                iconb64 = imgtool.GetBase64();
+                    
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+                null, null, null, null, null, iconb64, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's verification level.
+        /// </summary>
         /// <param name="verification_level">New verification level.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetVerificationLevelAsync(VerificationLevel verification_level, string reason = null)
+        {                    
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, verification_level, 
+                null, null, null, null, null, null, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's default message notifications.
+        /// </summary>
         /// <param name="default_message_notifications">New default notification settings.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetDefaultMessageNotificationsAsync(DefaultMessageNotifications default_message_notifications, string reason = null)
+        {
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+                default_message_notifications, null, null, null, null, null, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's MFA requirement setting.
+        /// </summary>
         /// <param name="mfa_level">New MFA requirement setting.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetMfaAsync(MfaLevel mfa_level, string reason = null)
+        {
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+                null, mfa_level, null, null, null, null, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's explicit content filter setting.
+        /// </summary>
         /// <param name="explicit_content_filter">New explicit content filter setting.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetExplicitContentFilterAsync(ExplicitContentFilter explicit_content_filter, string reason = null)
+        {
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+                null, null, explicit_content_filter, null, null, null, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's AFK voice channel.
+        /// </summary>
         /// <param name="afk_channel">New voice AFK channel.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetAfkChannelAsync(DiscordChannel afk_channel, string reason = null)
+        {
+            if (afk_channel.Type != ChannelType.Voice)
+                throw new ArgumentException("AFK channel needs to be a voice channel.");
+
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+                null, null, null, afk_channel.Id, null, null, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's AFK timeout (in seconds).
+        /// </summary>
         /// <param name="afk_timeout">New timeout after users are going to be moved to the voice AFK channel in seconds.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetAfkTimeoutAsync(int afk_timeout, string reason = null)
+        {
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+                null, null, null, null, afk_timeout, null, null, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's owner.
+        /// </summary>
         /// <param name="owner">New owner. This can only be changed by current owner.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns>The modified guild object.</returns>
+        public Task<DiscordGuild> SetOwnerAsync(DiscordMember owner, string reason = null)
+        {
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+                null, null, null, null, null, null, owner.Id, null, reason);
+        }
+        
+        /// <summary>
+        /// Sets this guild's invite splash.
+        /// </summary>
         /// <param name="splash">New invite splash.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> ModifyAsync(string name = null, DiscordVoiceRegion region = null, Stream icon = null, VerificationLevel? verification_level = null,
-            DefaultMessageNotifications? default_message_notifications = null, MfaLevel? mfa_level = null, ExplicitContentFilter? explicit_content_filter = null, DiscordChannel afk_channel = null, 
-            int? afk_timeout = null, DiscordMember owner = null, Stream splash = null, string reason = null)
+        public Task<DiscordGuild> SetInviteSplashAsync(DiscordMember owner, string reason = null)
         {
-            if (afk_channel != null && afk_channel.Type != ChannelType.Voice)
-                throw new ArgumentException("AFK channel needs to be a voice channel.");
-
-            string iconb64 = null;
-            if (icon != null)
-                using (var imgtool = new ImageTool(icon))
-                    iconb64 = imgtool.GetBase64();
-
             string splashb64 = null;
-            if (splash != null)
-                using (var imgtool = new ImageTool(splash))
-                    splashb64 = imgtool.GetBase64();
+            using (var imgtool = new ImageTool(splash))
+                splashb64 = imgtool.GetBase64();
 
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, name, region?.Id, verification_level, default_message_notifications, mfa_level, explicit_content_filter, afk_channel?.Id, 
-                afk_timeout, iconb64, owner?.Id, splashb64, reason).ConfigureAwait(false);
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+                null, null, null, null, null, null, null, splashb64, reason);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -302,7 +302,7 @@ namespace DSharpPlus.Entities
         /// <param name="name">New name.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> RenameAsync(string name, string reason = null)
+        public Task<DiscordGuild> RenameAsync(string name, string reason = null)
         {
             return this.Discord.ApiClient.ModifyGuildAsync(this.Id, name, null, null, 
                 null, null, null, null, null, null, null, null, reason);
@@ -314,9 +314,9 @@ namespace DSharpPlus.Entities
         /// <param name="region">New voice region.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetVoiceRegionAsync(DiscordVoiceRegion region, string reason = null)
+        public Task<DiscordGuild> SetVoiceRegionAsync(DiscordVoiceRegion region, string reason = null)
         {
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, region.Id, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, region.Id, null, 
                 null, null, null, null, null, null, null, null, reason);
         }
         
@@ -326,13 +326,13 @@ namespace DSharpPlus.Entities
         /// <param name="icon">New icon.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetIconAsync(Stream icon, string reason = null)
+        public Task<DiscordGuild> SetIconAsync(Stream icon, string reason = null)
         {
             string iconb64 = null;
             using (var imgtool = new ImageTool(icon))
                 iconb64 = imgtool.GetBase64();
                     
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, null, null, iconb64, null, null, reason);
         }
         
@@ -342,9 +342,9 @@ namespace DSharpPlus.Entities
         /// <param name="verification_level">New verification level.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetVerificationLevelAsync(VerificationLevel verification_level, string reason = null)
+        public Task<DiscordGuild> SetVerificationLevelAsync(VerificationLevel verification_level, string reason = null)
         {                    
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, verification_level, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, verification_level, 
                 null, null, null, null, null, null, null, null, reason);
         }
         
@@ -354,9 +354,9 @@ namespace DSharpPlus.Entities
         /// <param name="default_message_notifications">New default notification settings.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetDefaultMessageNotificationsAsync(DefaultMessageNotifications default_message_notifications, string reason = null)
+        public Task<DiscordGuild> SetDefaultMessageNotificationsAsync(DefaultMessageNotifications default_message_notifications, string reason = null)
         {
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 default_message_notifications, null, null, null, null, null, null, null, reason);
         }
         
@@ -366,9 +366,9 @@ namespace DSharpPlus.Entities
         /// <param name="mfa_level">New MFA requirement setting.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetMfaAsync(MfaLevel mfa_level, string reason = null)
+        public Task<DiscordGuild> SetMfaAsync(MfaLevel mfa_level, string reason = null)
         {
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, mfa_level, null, null, null, null, null, null, reason);
         }
         
@@ -378,9 +378,9 @@ namespace DSharpPlus.Entities
         /// <param name="explicit_content_filter">New explicit content filter setting.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetExplicitContentFilterAsync(ExplicitContentFilter explicit_content_filter, string reason = null)
+        public Task<DiscordGuild> SetExplicitContentFilterAsync(ExplicitContentFilter explicit_content_filter, string reason = null)
         {
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, explicit_content_filter, null, null, null, null, null, reason);
         }
         
@@ -390,12 +390,12 @@ namespace DSharpPlus.Entities
         /// <param name="afk_channel">New voice AFK channel.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetAfkChannelAsync(DiscordChannel afk_channel, string reason = null)
+        public Task<DiscordGuild> SetAfkChannelAsync(DiscordChannel afk_channel, string reason = null)
         {
             if (afk_channel.Type != ChannelType.Voice)
                 throw new ArgumentException("AFK channel needs to be a voice channel.");
 
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, afk_channel.Id, null, null, null, null, reason);
         }
         
@@ -405,9 +405,9 @@ namespace DSharpPlus.Entities
         /// <param name="afk_timeout">New timeout after users are going to be moved to the voice AFK channel in seconds.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetAfkTimeoutAsync(int afk_timeout, string reason = null)
+        public Task<DiscordGuild> SetAfkTimeoutAsync(int afk_timeout, string reason = null)
         {
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, null, afk_timeout, null, null, null, reason);
         }
         
@@ -417,9 +417,9 @@ namespace DSharpPlus.Entities
         /// <param name="owner">New owner. This can only be changed by current owner.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetOwnerAsync(DiscordMember owner, string reason = null)
+        public Task<DiscordGuild> SetOwnerAsync(DiscordMember owner, string reason = null)
         {
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, null, null, null, owner.Id, null, reason);
         }
         
@@ -429,13 +429,13 @@ namespace DSharpPlus.Entities
         /// <param name="splash">New invite splash.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The modified guild object.</returns>
-        public async Task<DiscordGuild> SetInviteSplashAsync(DiscordMember owner, string reason = null)
+        public Task<DiscordGuild> SetInviteSplashAsync(Stream splash, string reason = null)
         {
             string splashb64 = null;
             using (var imgtool = new ImageTool(splash))
                 splashb64 = imgtool.GetBase64();
 
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
+            return this.Discord.ApiClient.ModifyGuildAsync(this.Id, null, null, null, 
                 null, null, null, null, null, null, null, splashb64, reason);
         }
 

--- a/DSharpPlus/Entities/DiscordGuildEmoji.cs
+++ b/DSharpPlus/Entities/DiscordGuildEmoji.cs
@@ -21,15 +21,24 @@ namespace DSharpPlus.Entities
         internal DiscordGuildEmoji() { }
 
         /// <summary>
-        /// Modifies this emoji.
+        /// Renames this emoji.
         /// </summary>
         /// <param name="name">New name for this emoji.</param>
-        /// <param name="roles">Roles for which this emoji will be available. This works only if your application is whitelisted as integration.</param>
         /// <param name="reason">Reason for audit log.</param>
         /// <returns>The modified emoji.</returns>
-        public Task<DiscordGuildEmoji> ModifyAsync(string name, IEnumerable<DiscordRole> roles = null, string reason = null) 
-            => this.Guild.ModifyEmojiAsync(this, name, roles, reason);
-
+        public Task<DiscordGuildEmoji> RenameAsync(string name, string reason = null) 
+            => this.Guild.ModifyEmojiAsync(this, name, null, reason);
+        
+        /// <summary>
+        /// Modifies the list of roles for which this emoji is available.
+        /// This works only if your application is whitelisted as integration.
+        /// </summary>
+        /// <param name="roles">Roles for which this emoji will be available.</param>
+        /// <param name="reason">Reason for audit log.</param>
+        /// <returns>The modified emoji.</returns>
+        public Task<DiscordGuildEmoji> SetRolesAsync(IEnumerable<DiscordRole> roles, string reason = null) 
+            => this.Guild.ModifyEmojiAsync(this, null, roles, reason);
+        
         /// <summary>
         /// Deletes this emoji.
         /// </summary>

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -297,31 +297,33 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.ModifyGuildMemberAsync(_guild_id, this.Id, null, null, null, deaf, null, reason);
 
         /// <summary>
-        /// Modifies this member.
+        /// Renames this member.
         /// </summary>
         /// <param name="nickname">Nickname to set for this member.</param>
-        /// <param name="roles">Roles to set for this member.</param>
-        /// <param name="mute">Whether the member is to be muted in voice.</param>
-        /// <param name="deaf">Whether the member is to be deafened in voice.</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns></returns>
+        public Task RenameAsync(string nickname, string reason = null)
+        {
+            if (nickname != null && this.Discord.CurrentUser.Id == this.Id)
+                return this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, nickname, reason).ConfigureAwait(false);
+            else
+                return this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, nickname, null, null, null, null, reason).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// Move this member to a voice channel.
+        /// </summary>
         /// <param name="voice_channel">Voice channel to put the member into.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
-        public async Task ModifyAsync(string nickname = null, IEnumerable<DiscordRole> roles = null, bool? mute = null, bool? deaf = null, DiscordChannel voice_channel = null, string reason = null)
+        public Task MoveToAsync(DiscordChannel voice_channel, string reason = null)
         {
-            if (voice_channel != null && voice_channel.Type != ChannelType.Voice)
+            if (voice_channel.Type != ChannelType.Voice)
                 throw new ArgumentException("Given channel is not a voice channel.", nameof(voice_channel));
 
-            if (nickname != null && this.Discord.CurrentUser.Id == this.Id)
-            {
-                await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, nickname, reason).ConfigureAwait(false);
-                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null, roles != null ? roles.Select(xr => xr.Id) : null, mute, deaf, voice_channel?.Id, reason).ConfigureAwait(false);
-            }
-            else
-            {
-                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, nickname, roles != null ? roles.Select(xr => xr.Id) : null, mute, deaf, voice_channel?.Id, reason).ConfigureAwait(false);
-            }
+            return this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null, null, null, null, voice_channel.Id, reason).ConfigureAwait(false);
         }
-
+        
         /// <summary>
         /// Grants a role to the member. 
         /// </summary>

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -302,12 +302,12 @@ namespace DSharpPlus.Entities
         /// <param name="nickname">Nickname to set for this member.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
-        public Task RenameAsync(string nickname, string reason = null)
+        public async Task RenameAsync(string nickname, string reason = null)
         {
             if (nickname != null && this.Discord.CurrentUser.Id == this.Id)
-                return this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, nickname, reason).ConfigureAwait(false);
+                await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, nickname, reason).ConfigureAwait(false);
             else
-                return this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, nickname, null, null, null, null, reason).ConfigureAwait(false);
+                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, nickname, null, null, null, null, reason).ConfigureAwait(false);
         }
         
         /// <summary>
@@ -316,12 +316,12 @@ namespace DSharpPlus.Entities
         /// <param name="voice_channel">Voice channel to put the member into.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
-        public Task MoveToAsync(DiscordChannel voice_channel, string reason = null)
+        public async Task MoveToAsync(DiscordChannel voice_channel, string reason = null)
         {
             if (voice_channel.Type != ChannelType.Voice)
                 throw new ArgumentException("Given channel is not a voice channel.", nameof(voice_channel));
 
-            return this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null, null, null, null, voice_channel.Id, reason).ConfigureAwait(false);
+            await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null, null, null, null, voice_channel.Id, reason).ConfigureAwait(false);
         }
         
         /// <summary>

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -58,13 +58,20 @@ namespace DSharpPlus.Entities
         internal DiscordWebhook() { }
 
         /// <summary>
-        /// Modifies this webhook.
+        /// Changes this webhook's name.
         /// </summary>
         /// <param name="name">New default name for this webhook.</param>
-        /// <param name="base64avatar"></param>
         /// <returns>The modified webhook.</returns>
-        public Task<DiscordWebhook> ModifyAsync(string name = null, string base64avatar = null) 
-            => this.Discord.ApiClient.ModifyWebhookAsync(this.Id, name, base64avatar, Token);
+        public Task<DiscordWebhook> SetNameAsync(string name) 
+            => this.Discord.ApiClient.ModifyWebhookAsync(this.Id, name, null, Token);
+
+        /// <summary>
+        /// Changes this webhook's avatar.
+        /// </summary>
+        /// <param name="base64avatar">Base64 encoded image in one of Discord's supported image types</param>
+        /// <returns>The modified webhook.</returns>
+        public Task<DiscordWebhook> SetAvatarAsync(string base64avatar) 
+            => this.Discord.ApiClient.ModifyWebhookAsync(this.Id, null, base64avatar, Token);
 
         /// <summary>
         /// Permanently deletes this webhook.


### PR DESCRIPTION
# Summary
Takes the concept from #206 (and #207) and applies it to all ModifyAsync methods.

# Details
This takes the ModifyAsync methods and breaks them down into smaller methods for each argument.

# Changes proposed
* Split DiscordWebhook.ModifyAsync into smaller methods (d5d9c64)
* Split DiscordChannel.ModifyAsync into smaller methods (ce314c4)
* Split DiscordMember.ModifyAsync into smaller methods (58975d5)
* Split DiscordGuildEmoji.ModifyAsync into smaller methods (d7f94fb)
* Split DiscordGuild.ModifyAsync into smaller methods (7ac68af)