### PR TITLE
Remove unused 'using' directives

### DIFF
--- a/DSharpPlus/DiscordShardedClient.cs
+++ b/DSharpPlus/DiscordShardedClient.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Net.Http;
 using System.Threading.Tasks;
-using DSharpPlus.Net.WebSocket;
-using DSharpPlus.Net.Udp;
 using DSharpPlus.Net;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;

--- a/DSharpPlus/Entities/DiscordActivity.cs
+++ b/DSharpPlus/Entities/DiscordActivity.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using DSharpPlus.Net.Abstractions;
-using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/ImageTool.cs
+++ b/DSharpPlus/ImageTool.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace DSharpPlus
 {

--- a/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
+++ b/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/DSharpPlus/Net/Abstractions/ClientProperties.cs
+++ b/DSharpPlus/Net/Abstractions/ClientProperties.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Reflection;
+#if !HAS_ENVIRONMENT
 using System.Runtime.InteropServices;
+#endif
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions

--- a/DSharpPlus/Net/Udp/IpEndpoint.cs
+++ b/DSharpPlus/Net/Udp/IpEndpoint.cs
@@ -1,10 +1,5 @@
 ﻿#if !NETSTANDARD1_1
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DSharpPlus.Net.Udp
 {


### PR DESCRIPTION
Yeah I really am not contributing anything good am I

# Summary
This PR removes unused 'using' directives.

# Details
* Remove unused 'using' directives in DiscordShardedClient.cs
* Remove unused 'using' directives in DiscordActivity.cs
* Remove unused 'using' directives in ImageTool.cs
* Remove unused 'using' directives in AuditLogAbstractions.cs
* Remove unused 'using' directives in IpEndpoint.cs
* Wrapped import in #if in ClientProperties.cs
* It'd be funny if the build failed for this, wouldn't it