### PR TITLE
mark CooldownBucketType as Flags enum

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/CooldownAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/CooldownAttribute.cs
@@ -122,7 +122,8 @@ namespace DSharpPlus.CommandsNext.Attributes
     /// <summary>
     /// Defines how are command cooldowns applied.
     /// </summary>
-    public enum CooldownBucketType : int
+    [Flags]
+    public enum CooldownBucketType
     {
         /// <summary>
         /// Denotes that the command will have its cooldown applied per-user.


### PR DESCRIPTION
# Summary
Adds the Flags attribute to CooldownBucketType.

# Details
Bitwise operations are performed on CooldownBucketType, but it's not marked with the Flags attribute. God forbid this fixes a ReSharper issue.

# Changes proposed
* Add the Flags attribute to CooldownBucketType.
