### PR TITLE
Implement DiscordGuild SystemChannel

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -41,9 +41,9 @@ namespace DSharpPlus
             => ApiClient.DeleteGuildAsync(id);
 
         public Task<DiscordGuild> ModifyGuildAsync(ulong guild_id, string name, string region, VerificationLevel? verification_level, DefaultMessageNotifications? default_message_notifications, 
-            MfaLevel? mfa_level, ExplicitContentFilter? explicit_content_filter, ulong? afk_channel_id, int? afk_timeout, string iconb64, ulong? owner_id, string splashb64, string reason) 
+            MfaLevel? mfa_level, ExplicitContentFilter? explicit_content_filter, ulong? afk_channel_id, int? afk_timeout, string iconb64, ulong? owner_id, string splashb64, string reason, bool hasSystemChannelId, ulong? systemChannelId) 
             => ApiClient.ModifyGuildAsync(guild_id, name, region, verification_level, default_message_notifications, mfa_level, explicit_content_filter, afk_channel_id, afk_timeout, iconb64, 
-                owner_id, splashb64, reason);
+                owner_id, splashb64, reason, hasSystemChannelId, systemChannelId);
 
         public Task<IReadOnlyList<DiscordBan>> GetGuildBansAsync(ulong guild_id) 
             => ApiClient.GetGuildBansAsync(guild_id);

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -132,6 +132,17 @@ namespace DSharpPlus.Entities
         [JsonProperty("explicit_content_filter")]
         public ExplicitContentFilter ExplicitContentFilter { get; internal set; }
 
+        [JsonProperty("system_channel_id", NullValueHandling = NullValueHandling.Include)]
+        internal ulong? SystemChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the channel to which system messages (such as join notifications) are sent.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel SystemChannel => SystemChannelId.HasValue
+            ? this.Channels.FirstOrDefault(xc => xc.Id == SystemChannelId)
+            : null;
+        
         /// <summary>
         /// Gets a collection of this guild's roles.
         /// </summary>
@@ -321,7 +332,8 @@ namespace DSharpPlus.Entities
 
             return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, mdl.Name, mdl.Region?.Id, mdl.VerificationLevel, mdl.DefaultMessageNotifications,
                 mdl.MfaLevel, mdl.ExplicitContentFilter, mdl.AfkChannel?.Id,
-                mdl.AfkTimeout, iconb64, mdl.Owner?.Id, splashb64, mdl.AuditLogReason).ConfigureAwait(false);
+                mdl.AfkTimeout, iconb64, mdl.Owner?.Id, splashb64, mdl.AuditLogReason, 
+                mdl.SystemChannel.HasValue, mdl.SystemChannel.HasValue ? mdl.SystemChannel.Value?.Id : null).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
@@ -56,6 +56,14 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("explicit_content_filter", NullValueHandling = NullValueHandling.Ignore)]
         public ExplicitContentFilter? ExplicitContentFilter { get; set; }
 
+        [JsonProperty("system_channel_id", NullValueHandling = NullValueHandling.Include)]
+        public ulong? SystemChannelId { get; set; }
+        
+        [JsonIgnore]
+        public bool HasSystemChannelId { get; set; }
+
+        public bool ShouldSerializeSystemChannelId() => HasSystemChannelId;
+
         // we no want that here
         [JsonIgnore]
         public new IEnumerable<DiscordRole> Roles { get; set; }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -160,7 +160,7 @@ namespace DSharpPlus.Net
 
         internal async Task<DiscordGuild> ModifyGuildAsync(ulong guild_id, string name, string region, VerificationLevel? verification_level,
             DefaultMessageNotifications? default_message_notifications, MfaLevel? mfa_level, ExplicitContentFilter? explicit_content_filter, ulong? afk_channel_id, int? afk_timeout, string iconb64,
-            ulong? owner_id, string splashb64, string reason)
+            ulong? owner_id, string splashb64, string reason, bool isSystemChannelSet, ulong? systemChannelId)
         {
             var pld = new RestGuildModifyPayload
             {
@@ -174,9 +174,11 @@ namespace DSharpPlus.Net
                 AfkTimeout = afk_timeout,
                 IconBase64 = iconb64,
                 SplashBase64 = splashb64,
-                OwnerId = owner_id
+                OwnerId = owner_id,
+                HasSystemChannelId = isSystemChannelSet,
+                SystemChannelId = systemChannelId
             };
-
+            
             var headers = Utilities.GetBaseHeaders();
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);

--- a/DSharpPlus/Net/Models/GuildEditModel.cs
+++ b/DSharpPlus/Net/Models/GuildEditModel.cs
@@ -22,6 +22,7 @@ namespace DSharpPlus.Net.Models
         public DiscordMember Owner { internal get; set; }
         public Stream Splash { internal get; set; }
         public string AuditLogReason { internal get; set; }
+        public Optional<DiscordChannel> SystemChannel { internal get; set; }
 
         internal GuildEditModel()
         {


### PR DESCRIPTION
# Summary
Implements SystemChannel (`system_channel_id` on API side). This controls what channel new member messages are sent to, and such.

# Details
## The problem
This boi:
![](https://i.imgur.com/iN6QO6d.png)
So, `system_channel_id` is a snowflake, and on guild modify it can be `null` to indicate no system channel, or not present to indicate no change. There is no easy way to represent this in C#. an `Optional<ulong?>` doesn't serialize properly (a non-null or a null with `NullValueHandling.Include` set will always be present, this is not what we want); `ulong?` is too broad (with `NullValueHandling.Include` this will disable system channel when we don't want it to. with `NullValueHandling.Ignore` this will make it impossible to disable system channel.)

## The solution
Currently: an `ulong?` with `NullValueHandling.Include` (so it's possible to disable system channel), but with `bool HasSystemChannelId` property that set only when the property is present, an `Optional<ulong?>` wrapper on the outside that sets HasSystemChannelId, and a `ShouldSerialize` method pointing to HasSystemChannelId, which JSON.NET will understand and properly ignore the value if necessary.

### The drawback
Well, we're adding an extra property and an extra method for every optional endpoint argument, which is far from optimal.

### The (potential) solution to the drawback
To be honest, I have no idea. A custom JsonConverter for `Optional<Nullable<struct>>` would probably work _if_ you can ignore the value from inside the JsonConverter. TODO: check whether this is possible.

### The alternative, hacky solution
Include the original SystemChannel as default for ModifyAsync. This introduces a race condition and a concept that all further optional endpoint arguments have to depend on, which is probably a bad idea.

# Changes proposed
* Update DiscordApiClient.ModifyGuildAsync to include system channel param
* Update DiscordGuild.ModifyAsync and GuildEditModel to include system channel
* Added DiscordGuild.SystemChannel (I have no clue if I did it right, I'm tired)

# Notes
Please don't immediately close this PR because I used camelCase for the variables instead of under_score
