### PR TITLE
Add serializer for Optional<T> that includes the property only if a value is present / make Modify Guild/Member endpoint parameters optional / implement Guild.SystemChannel

### DIFF
--- a/DSharpPlus.MSTest/DSharpPlus.MSTest.csproj
+++ b/DSharpPlus.MSTest/DSharpPlus.MSTest.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
+  </ItemGroup>
+</Project>

--- a/DSharpPlus.MSTest/DSharpPlus.MSTest.csproj
+++ b/DSharpPlus.MSTest/DSharpPlus.MSTest.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/DSharpPlus.MSTest/TestJson.cs
+++ b/DSharpPlus.MSTest/TestJson.cs
@@ -1,0 +1,30 @@
+﻿using DSharpPlus.Entities;
+using DSharpPlus.Net.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Test
+{
+    [TestClass]
+    public class TestJson
+    {
+        [TestMethod]
+        public void TestOptionalSerialization()
+        {
+            // ulong
+            Assert.AreEqual("[0]", DiscordJson.SerializeObject(new[] { new Optional<ulong?>(0UL) }));
+            Assert.AreEqual("[]" , DiscordJson.SerializeObject(new[] { new Optional<ulong?>() }));
+            // bool
+            Assert.AreEqual("[true]" , DiscordJson.SerializeObject(new[] { new Optional<bool?>(true) }));
+            Assert.AreEqual("[false]", DiscordJson.SerializeObject(new[] { new Optional<bool?>(false) }));
+            Assert.AreEqual("[]"     , DiscordJson.SerializeObject(new[] { new Optional<bool?>() }));
+            
+            Assert.AreEqual(@"[{""HasValue"":true,""Value"":0}]", DiscordJson.SerializeObject(new[] { new Optional<ulong>(0UL) }));
+            // `System.InvalidOperationException: Value is not set.` wrapped in JsonSerializationException 
+            Assert.ThrowsException<JsonSerializationException>(() =>
+            {
+                DiscordJson.SerializeObject(new[] {new Optional<ulong>()});
+            });
+        }
+    }
+}

--- a/DSharpPlus.MSTest/TestJson.cs
+++ b/DSharpPlus.MSTest/TestJson.cs
@@ -1,4 +1,5 @@
 ﻿using DSharpPlus.Entities;
+using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -22,6 +23,27 @@ namespace DSharpPlus.Test
             Assert.AreEqual("[true]" , DiscordJson.SerializeObject(new[] { new Optional<bool>(true) }));
             Assert.AreEqual("[false]", DiscordJson.SerializeObject(new[] { new Optional<bool>(false) }));
             Assert.AreEqual("[]"     , DiscordJson.SerializeObject(new[] { new Optional<bool>() }));
+        }
+
+        [TestMethod]
+        public void TestOptionalSerialization2()
+        {
+            var p = new RestGuildModifyPayload();
+            Assert.AreEqual("{}", DiscordJson.SerializeObject(p));
+            Assert.AreEqual("{}", DiscordJson.SerializeObject(new RestGuildModifyPayload()
+            {
+                SystemChannelId = default,
+            }));
+            Assert.AreEqual(@"{""name"":""doobilip"",""system_channel_id"":null}", DiscordJson.SerializeObject(new RestGuildModifyPayload()
+            {
+                Name = "doobilip",
+                SystemChannelId = null,
+            }));
+            Assert.AreEqual(@"{""name"":""doobilip2"",""system_channel_id"":420}", DiscordJson.SerializeObject(new RestGuildModifyPayload()
+            {
+                Name = "doobilip2",
+                SystemChannelId = 420,
+            }));
         }
     }
 }

--- a/DSharpPlus.MSTest/TestJson.cs
+++ b/DSharpPlus.MSTest/TestJson.cs
@@ -6,6 +6,19 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Test
 {
+    public class TestFixture1
+    {
+        public Optional<ulong?> Entry { get; set; }
+    }
+    public class TestFixture2
+    {
+        public Optional<bool?> Entry { get; set; }
+    }
+    public class TestFixture3
+    {
+        public Optional<bool> Entry { get; set; }
+    }
+    
     [TestClass]
     public class TestJson
     {
@@ -13,16 +26,16 @@ namespace DSharpPlus.Test
         public void TestOptionalSerialization()
         {
             // ulong
-            Assert.AreEqual("[0]", DiscordJson.SerializeObject(new[] { new Optional<ulong?>(0UL) }));
-            Assert.AreEqual("[]" , DiscordJson.SerializeObject(new[] { new Optional<ulong?>() }));
+            Assert.AreEqual(@"{""Entry"":0}", DiscordJson.SerializeObject(new TestFixture1 { Entry = new Optional<ulong?>(0UL) }));
+            Assert.AreEqual(@"{}" , DiscordJson.SerializeObject(new TestFixture1 { Entry = new Optional<ulong?>() }));
             // bool?
-            Assert.AreEqual("[true]" , DiscordJson.SerializeObject(new[] { new Optional<bool?>(true) }));
-            Assert.AreEqual("[false]", DiscordJson.SerializeObject(new[] { new Optional<bool?>(false) }));
-            Assert.AreEqual("[]"     , DiscordJson.SerializeObject(new[] { new Optional<bool?>() }));
+            Assert.AreEqual(@"{""Entry"":true}" , DiscordJson.SerializeObject(new TestFixture2 { Entry = new Optional<bool?>(true) }));
+            Assert.AreEqual(@"{""Entry"":false}", DiscordJson.SerializeObject(new TestFixture2 { Entry = new Optional<bool?>(false) }));
+            Assert.AreEqual(@"{}"     , DiscordJson.SerializeObject(new TestFixture2 { Entry = new Optional<bool?>() }));
             // bool
-            Assert.AreEqual("[true]" , DiscordJson.SerializeObject(new[] { new Optional<bool>(true) }));
-            Assert.AreEqual("[false]", DiscordJson.SerializeObject(new[] { new Optional<bool>(false) }));
-            Assert.AreEqual("[]"     , DiscordJson.SerializeObject(new[] { new Optional<bool>() }));
+            Assert.AreEqual(@"{""Entry"":true}" , DiscordJson.SerializeObject(new TestFixture3 { Entry = new Optional<bool>(true) }));
+            Assert.AreEqual(@"{""Entry"":false}", DiscordJson.SerializeObject(new TestFixture3 { Entry = new Optional<bool>(false) }));
+            Assert.AreEqual(@"{}"     , DiscordJson.SerializeObject(new TestFixture3 { Entry = new Optional<bool>() }));
         }
 
         [TestMethod]

--- a/DSharpPlus.MSTest/TestJson.cs
+++ b/DSharpPlus.MSTest/TestJson.cs
@@ -14,17 +14,14 @@ namespace DSharpPlus.Test
             // ulong
             Assert.AreEqual("[0]", DiscordJson.SerializeObject(new[] { new Optional<ulong?>(0UL) }));
             Assert.AreEqual("[]" , DiscordJson.SerializeObject(new[] { new Optional<ulong?>() }));
-            // bool
+            // bool?
             Assert.AreEqual("[true]" , DiscordJson.SerializeObject(new[] { new Optional<bool?>(true) }));
             Assert.AreEqual("[false]", DiscordJson.SerializeObject(new[] { new Optional<bool?>(false) }));
             Assert.AreEqual("[]"     , DiscordJson.SerializeObject(new[] { new Optional<bool?>() }));
-            
-            Assert.AreEqual(@"[{""HasValue"":true,""Value"":0}]", DiscordJson.SerializeObject(new[] { new Optional<ulong>(0UL) }));
-            // `System.InvalidOperationException: Value is not set.` wrapped in JsonSerializationException 
-            Assert.ThrowsException<JsonSerializationException>(() =>
-            {
-                DiscordJson.SerializeObject(new[] {new Optional<ulong>()});
-            });
+            // bool
+            Assert.AreEqual("[true]" , DiscordJson.SerializeObject(new[] { new Optional<bool>(true) }));
+            Assert.AreEqual("[false]", DiscordJson.SerializeObject(new[] { new Optional<bool>(false) }));
+            Assert.AreEqual("[]"     , DiscordJson.SerializeObject(new[] { new Optional<bool>() }));
         }
     }
 }

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -252,7 +252,9 @@ namespace DSharpPlus
         public Task<IReadOnlyList<DiscordGuild>> GetCurrentUserGuildsAsync(int limit, ulong? before, ulong? after)
             => ApiClient.GetCurrentUserGuildsAsync(limit, before, after);
 
-        public Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, string nick, IEnumerable<ulong> role_ids, bool? mute, bool? deaf, ulong? voice_channel_id, string reason)
+        public Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, Optional<string> nick,
+            Optional<IEnumerable<ulong>> role_ids, Optional<bool> mute, Optional<bool> deaf,
+            Optional<ulong> voice_channel_id, string reason)
             => ApiClient.ModifyGuildMemberAsync(guild_id, user_id, nick, role_ids, mute, deaf, voice_channel_id, reason);
 
         public Task ModifyCurrentMemberNicknameAsync(ulong guild_id, string nick, string reason)

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -81,7 +81,7 @@ namespace DSharpPlus
                         continue;
 
                     var usr = new DiscordUser(xtm.User) { Discord = this };
-                    usr = this.UserCache.AddOrUpdate(xtm.User.Id, usr, (id, old) =>
+                    this.UserCache.AddOrUpdate(xtm.User.Id, usr, (id, old) =>
                     {
                         old.Username = usr.Username;
                         old.Discord = usr.Discord;
@@ -92,10 +92,7 @@ namespace DSharpPlus
                 }
 
                 var tm = tms.LastOrDefault();
-                if (tm != null)
-                    last = tm.User.Id;
-                else
-                    last = 0;
+                last = tm?.User.Id ?? 0;
 
                 recmbr.AddRange(tms.Select(xtm => new DiscordMember(xtm) { Discord = this, _guild_id = guild_id }));
             }
@@ -111,7 +108,7 @@ namespace DSharpPlus
 
         public Task UpdateRolePositionAsync(ulong guild_id, ulong role_id, int position, string reason = null)
         {
-            List<RestGuildRoleReorderPayload> rgrrps = new List<RestGuildRoleReorderPayload>()
+            var rgrrps = new List<RestGuildRoleReorderPayload>()
             {
                 new RestGuildRoleReorderPayload { RoleId = role_id }
             };
@@ -120,7 +117,7 @@ namespace DSharpPlus
 
         public Task UpdateChannelPositionAsync(ulong guild_id, ulong channel_id, int position, string reason)
         {
-            List<RestGuildChannelReorderPayload> rgcrps = new List<RestGuildChannelReorderPayload>()
+            var rgcrps = new List<RestGuildChannelReorderPayload>()
             {
                 new RestGuildChannelReorderPayload { ChannelId = channel_id, Position = position }
             };
@@ -269,7 +266,7 @@ namespace DSharpPlus
             => ApiClient.GetGuildAsync(guild_id);
 
         public Task<DiscordRole> ModifyGuildRoleAsync(ulong guild_id, ulong role_id, string name, Permissions? permissions, int? color, bool? hoist, bool? mentionable, string reason)
-            => ModifyGuildRoleAsync(guild_id, role_id, name, permissions, color, hoist, mentionable, reason);
+            => ApiClient.ModifyGuildRoleAsync(guild_id, role_id, name, permissions, color, hoist, mentionable, reason);
 
         public Task DeleteRoleAsync(ulong guild_id, ulong role_id, string reason)
             => ApiClient.DeleteRoleAsync(guild_id, role_id, reason);
@@ -294,7 +291,7 @@ namespace DSharpPlus
             => ApiClient.CreateGuildIntegrationAsync(guild_id, type, id);
 
         public Task<DiscordIntegration> ModifyGuildIntegrationAsync(ulong guild_id, ulong integration_id, int expire_behaviour, int expire_grace_period, bool enable_emoticons)
-            => ModifyGuildIntegrationAsync(guild_id, integration_id, expire_behaviour, expire_grace_period, enable_emoticons);
+            => ApiClient.ModifyGuildIntegrationAsync(guild_id, integration_id, expire_behaviour, expire_grace_period, enable_emoticons);
 
         public Task DeleteGuildIntegrationAsync(ulong guild_id, DiscordIntegration integration) 
             => ApiClient.DeleteGuildIntegrationAsync(guild_id, integration);
@@ -303,7 +300,7 @@ namespace DSharpPlus
             => ApiClient.SyncGuildIntegrationAsync(guild_id, integration_id);
 
         public Task<DiscordGuildEmbed> GetGuildEmbedAsync(ulong guild_id) 
-            => GetGuildEmbedAsync(guild_id);
+            => ApiClient.GetGuildEmbedAsync(guild_id);
 
         public Task<DiscordGuildEmbed> ModifyGuildEmbedAsync(ulong guild_id, DiscordGuildEmbed embed) 
             => ApiClient.ModifyGuildEmbedAsync(guild_id, embed);

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -40,10 +40,14 @@ namespace DSharpPlus
         public Task DeleteGuildAsync(ulong id) 
             => ApiClient.DeleteGuildAsync(id);
 
-        public Task<DiscordGuild> ModifyGuildAsync(ulong guild_id, string name, string region, VerificationLevel? verification_level, DefaultMessageNotifications? default_message_notifications, 
-            MfaLevel? mfa_level, ExplicitContentFilter? explicit_content_filter, ulong? afk_channel_id, int? afk_timeout, string iconb64, ulong? owner_id, string splashb64, string reason, bool hasSystemChannelId, ulong? systemChannelId) 
+        public Task<DiscordGuild> ModifyGuildAsync(ulong guild_id, Optional<string> name,
+            Optional<string> region, Optional<VerificationLevel> verification_level,
+            Optional<DefaultMessageNotifications> default_message_notifications, Optional<MfaLevel> mfa_level,
+            Optional<ExplicitContentFilter> explicit_content_filter, Optional<ulong> afk_channel_id,
+            Optional<int> afk_timeout, Optional<string> iconb64, Optional<ulong> owner_id, Optional<string> splashb64,
+            Optional<ulong?> systemChannelId, string reason)
             => ApiClient.ModifyGuildAsync(guild_id, name, region, verification_level, default_message_notifications, mfa_level, explicit_content_filter, afk_channel_id, afk_timeout, iconb64, 
-                owner_id, splashb64, reason, hasSystemChannelId, systemChannelId);
+                owner_id, splashb64, systemChannelId, reason);
 
         public Task<IReadOnlyList<DiscordBan>> GetGuildBansAsync(ulong guild_id) 
             => ApiClient.GetGuildBansAsync(guild_id);

--- a/DSharpPlus/DSharpPlus.csproj
+++ b/DSharpPlus/DSharpPlus.csproj
@@ -1,48 +1,61 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="../DSharpPlus.targets" />
+
   <PropertyGroup>
     <AssemblyName>DSharpPlus</AssemblyName>
     <RootNamespace>DSharpPlus</RootNamespace>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net45;net46;net47;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
+
   <PropertyGroup>
     <Description>A C# API for Discord based off DiscordSharp, but rewritten to fit the API standards.</Description>
     <PackageTags>discord discord-api bots discord-bots chat dsharp dsharpplus csharp dotnet vb-net fsharp webhooks</PackageTags>
   </PropertyGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <Compile Remove="Net\WebSocket\WebSocketClient.cs" />
     <Compile Remove="Net\Udp\DspUdpClient.cs" />
   </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <None Include="Net\WebSocket\WebSocketClient.cs" />
     <None Include="Net\Udp\DspUdpClient.cs" />
   </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.1'">
     <Compile Remove="Net\WebSocket\WebSocketClient2.cs" />
     <Compile Remove="Net\Udp\DspUdpClient2.cs" />
   </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.1'">
     <None Include="Net\WebSocket\WebSocketClient2.cs" />
     <None Include="Net\Udp\DspUdpClient2.cs" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' Or '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net47'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+  
 </Project>

--- a/DSharpPlus/DSharpPlus.csproj
+++ b/DSharpPlus/DSharpPlus.csproj
@@ -1,61 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <Import Project="../DSharpPlus.targets" />
-
   <PropertyGroup>
     <AssemblyName>DSharpPlus</AssemblyName>
     <RootNamespace>DSharpPlus</RootNamespace>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net45;net46;net47;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-
   <PropertyGroup>
     <Description>A C# API for Discord based off DiscordSharp, but rewritten to fit the API standards.</Description>
     <PackageTags>discord discord-api bots discord-bots chat dsharp dsharpplus csharp dotnet vb-net fsharp webhooks</PackageTags>
   </PropertyGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <Compile Remove="Net\WebSocket\WebSocketClient.cs" />
     <Compile Remove="Net\Udp\DspUdpClient.cs" />
   </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <None Include="Net\WebSocket\WebSocketClient.cs" />
     <None Include="Net\Udp\DspUdpClient.cs" />
   </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.1'">
     <Compile Remove="Net\WebSocket\WebSocketClient2.cs" />
     <Compile Remove="Net\Udp\DspUdpClient2.cs" />
   </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.1'">
     <None Include="Net\WebSocket\WebSocketClient2.cs" />
     <None Include="Net\Udp\DspUdpClient2.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' Or '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net47'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  
 </Project>

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -459,7 +459,8 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Voice)
                 throw new ArgumentException("Cannot place member in a non-voice channel!"); // be a little more angery, let em learn!!1
             
-            await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, member.Id, null, null, null, null, this.Id, null).ConfigureAwait(false);
+            await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, member.Id, default, default, default,
+                default, this.Id, null).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -317,23 +317,23 @@ namespace DSharpPlus.Entities
         {
             var mdl = new GuildEditModel();
             action(mdl);
-            if (mdl.AfkChannel != null && mdl.AfkChannel.Type != ChannelType.Voice)
+            if (mdl.AfkChannel.HasValue && mdl.AfkChannel.Value.Type != ChannelType.Voice)
                 throw new ArgumentException("AFK channel needs to be a voice channel.");
 
-            string iconb64 = null;
-            if (mdl.Icon != null)
-                using (var imgtool = new ImageTool(mdl.Icon))
+            Optional<string> iconb64 = default;
+            if (mdl.Icon.HasValue)
+                using (var imgtool = new ImageTool(mdl.Icon.Value))
                     iconb64 = imgtool.GetBase64();
 
-            string splashb64 = null;
-            if (mdl.Splash != null)
-                using (var imgtool = new ImageTool(mdl.Splash))
+            Optional<string> splashb64 = default;
+            if (mdl.Splash.HasValue)
+                using (var imgtool = new ImageTool(mdl.Splash.Value))
                     splashb64 = imgtool.GetBase64();
 
-            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, mdl.Name, mdl.Region?.Id, mdl.VerificationLevel, mdl.DefaultMessageNotifications,
-                mdl.MfaLevel, mdl.ExplicitContentFilter, mdl.AfkChannel?.Id,
-                mdl.AfkTimeout, iconb64, mdl.Owner?.Id, splashb64, mdl.AuditLogReason, 
-                mdl.SystemChannel.HasValue, mdl.SystemChannel.HasValue ? mdl.SystemChannel.Value?.Id : null).ConfigureAwait(false);
+            return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, mdl.Name, mdl.Region.IfPresent(e => e.Id),
+                mdl.VerificationLevel, mdl.DefaultMessageNotifications, mdl.MfaLevel, mdl.ExplicitContentFilter,
+                mdl.AfkChannel.IfPresent(e => e.Id), mdl.AfkTimeout, iconb64, mdl.Owner.IfPresent(e => e.Id), splashb64,
+                mdl.SystemChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -307,19 +307,22 @@ namespace DSharpPlus.Entities
             var mdl = new MemberEditModel();
             action(mdl);
 
-            if (mdl.VoiceChannel != null && mdl.VoiceChannel.Type != ChannelType.Voice)
+            if (mdl.VoiceChannel.HasValue && mdl.VoiceChannel.Value.Type != ChannelType.Voice)
                 throw new ArgumentException("Given channel is not a voice channel.", nameof(mdl.VoiceChannel));
 
-            if (mdl.Nickname != null && this.Discord.CurrentUser.Id == this.Id)
+            if (mdl.Nickname.HasValue && this.Discord.CurrentUser.Id == this.Id)
             {
-                await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, mdl.Nickname, mdl.AuditLogReason).ConfigureAwait(false);
-                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null, mdl.Roles != null ? mdl.Roles.Select(xr => xr.Id) : null,
-                    mdl.Muted, mdl.Deafened, mdl.VoiceChannel?.Id, mdl.AuditLogReason).ConfigureAwait(false);
+                await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, mdl.Nickname.Value,
+                    mdl.AuditLogReason).ConfigureAwait(false);
+                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null,
+                    mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
+                    mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }
             else
             {
-                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, mdl.Nickname, mdl.Roles != null ? mdl.Roles.Select(xr => xr.Id) : null,
-                    mdl.Muted, mdl.Deafened, mdl.VoiceChannel?.Id, mdl.AuditLogReason).ConfigureAwait(false);
+                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, mdl.Nickname,
+                    mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
+                    mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -286,7 +286,7 @@ namespace DSharpPlus.Entities
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
         public Task SetMuteAsync(bool mute, string reason = null) 
-            => this.Discord.ApiClient.ModifyGuildMemberAsync(_guild_id, this.Id, null, null, mute, null, null, reason);
+            => this.Discord.ApiClient.ModifyGuildMemberAsync(_guild_id, this.Id, default, default, mute, default, default, reason);
         
         /// <summary>
         /// Sets this member's voice deaf status.
@@ -295,7 +295,7 @@ namespace DSharpPlus.Entities
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
         public Task SetDeafAsync(bool deaf, string reason = null) 
-            => this.Discord.ApiClient.ModifyGuildMemberAsync(_guild_id, this.Id, null, null, null, deaf, null, reason);
+            => this.Discord.ApiClient.ModifyGuildMemberAsync(_guild_id, this.Id, default, default, default, deaf, default, reason);
 
         /// <summary>
         /// Modifies this member.
@@ -351,7 +351,8 @@ namespace DSharpPlus.Entities
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
         public Task ReplaceRolesAsync(IEnumerable<DiscordRole> roles, string reason = null) 
-            => this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null, roles.Select(xr => xr.Id), null, null, null, reason);
+            => this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, default,
+                new Optional<IEnumerable<ulong>>(roles.Select(xr => xr.Id)), default, default, default, reason);
 
         /// <summary>
         /// Bans a this member from their guild.

--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -132,5 +132,10 @@ namespace DSharpPlus.Entities
 
         public static bool operator !=(Optional<T> opt, T t) 
             => !opt.Equals(t);
+
+        public Optional<TTarget> IfPresent<TTarget>(Func<T, TTarget> mapper)
+        {
+            return HasValue ? new Optional<TTarget>(mapper(Value)) : default;
+        }
     }
 }

--- a/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
@@ -36,41 +36,43 @@ namespace DSharpPlus.Net.Abstractions
         public IEnumerable<RestChannelCreatePayload> Channels { get; set; }
     }
 
-    internal sealed class RestGuildModifyPayload : RestGuildCreatePayload
+    internal sealed class RestGuildModifyPayload
     {
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public Optional<string> Name { get; set; }
+
+        [JsonProperty("region", NullValueHandling = NullValueHandling.Ignore)]
+        public Optional<string> RegionId { get; set; }
+        
+        [JsonProperty("icon", NullValueHandling = NullValueHandling.Ignore)]
+        public Optional<string> IconBase64 { get; set; }
+
+        [JsonProperty("verification_level", NullValueHandling = NullValueHandling.Ignore)]
+        public Optional<VerificationLevel> VerificationLevel { get; set; }
+
+        [JsonProperty("default_message_notifications", NullValueHandling = NullValueHandling.Ignore)]
+        public Optional<DefaultMessageNotifications> DefaultMessageNotifications { get; set; }
+
         [JsonProperty("owner_id", NullValueHandling = NullValueHandling.Ignore)]
-        public ulong? OwnerId { get; set; }
+        public Optional<ulong> OwnerId { get; set; }
 
         [JsonProperty("splash", NullValueHandling = NullValueHandling.Ignore)]
-        public string SplashBase64 { get; set; }
+        public Optional<string> SplashBase64 { get; set; }
 
         [JsonProperty("afk_channel_id", NullValueHandling = NullValueHandling.Ignore)]
-        public ulong? AfkChannelId { get; set; }
+        public Optional<ulong> AfkChannelId { get; set; }
 
         [JsonProperty("afk_timeout", NullValueHandling = NullValueHandling.Ignore)]
-        public int? AfkTimeout { get; set; }
+        public Optional<int> AfkTimeout { get; set; }
 
         [JsonProperty("mfa_level", NullValueHandling = NullValueHandling.Ignore)]
-        public MfaLevel? MfaLevel { get; set; }
+        public Optional<MfaLevel> MfaLevel { get; set; }
 
         [JsonProperty("explicit_content_filter", NullValueHandling = NullValueHandling.Ignore)]
-        public ExplicitContentFilter? ExplicitContentFilter { get; set; }
+        public Optional<ExplicitContentFilter> ExplicitContentFilter { get; set; }
 
         [JsonProperty("system_channel_id", NullValueHandling = NullValueHandling.Include)]
-        public ulong? SystemChannelId { get; set; }
-        
-        [JsonIgnore]
-        public bool HasSystemChannelId { get; set; }
-
-        public bool ShouldSerializeSystemChannelId() => HasSystemChannelId;
-
-        // we no want that here
-        [JsonIgnore]
-        public new IEnumerable<DiscordRole> Roles { get; set; }
-
-        // we no want that here
-        [JsonIgnore]
-        public new IEnumerable<RestChannelCreatePayload> Channels { get; set; }
+        public Optional<ulong?> SystemChannelId { get; set; }
     }
     
     internal sealed class RestGuildMemberAddPayload : IOAuth2Payload

--- a/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
@@ -38,37 +38,37 @@ namespace DSharpPlus.Net.Abstractions
 
     internal sealed class RestGuildModifyPayload
     {
-        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("name")]
         public Optional<string> Name { get; set; }
 
-        [JsonProperty("region", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("region")]
         public Optional<string> RegionId { get; set; }
         
-        [JsonProperty("icon", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("icon")]
         public Optional<string> IconBase64 { get; set; }
 
-        [JsonProperty("verification_level", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("verification_level")]
         public Optional<VerificationLevel> VerificationLevel { get; set; }
 
-        [JsonProperty("default_message_notifications", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("default_message_notifications")]
         public Optional<DefaultMessageNotifications> DefaultMessageNotifications { get; set; }
 
-        [JsonProperty("owner_id", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("owner_id")]
         public Optional<ulong> OwnerId { get; set; }
 
-        [JsonProperty("splash", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("splash")]
         public Optional<string> SplashBase64 { get; set; }
 
-        [JsonProperty("afk_channel_id", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("afk_channel_id")]
         public Optional<ulong> AfkChannelId { get; set; }
 
-        [JsonProperty("afk_timeout", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("afk_timeout")]
         public Optional<int> AfkTimeout { get; set; }
 
-        [JsonProperty("mfa_level", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("mfa_level")]
         public Optional<MfaLevel> MfaLevel { get; set; }
 
-        [JsonProperty("explicit_content_filter", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("explicit_content_filter")]
         public Optional<ExplicitContentFilter> ExplicitContentFilter { get; set; }
 
         [JsonProperty("system_channel_id", NullValueHandling = NullValueHandling.Include)]

--- a/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
@@ -113,20 +113,20 @@ namespace DSharpPlus.Net.Abstractions
 
     internal sealed class RestGuildMemberModifyPayload
     {
-        [JsonProperty("nick", NullValueHandling = NullValueHandling.Ignore)]
-        public string Nickname { get; set; }
+        [JsonProperty("nick")]
+        public Optional<string> Nickname { get; set; }
 
-        [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
-        public IEnumerable<ulong> RoleIds { get; set; }
+        [JsonProperty("roles")]
+        public Optional<IEnumerable<ulong>> RoleIds { get; set; }
 
-        [JsonProperty("mute", NullValueHandling = NullValueHandling.Ignore)]
-        public bool? Mute { get; set; }
+        [JsonProperty("mute")]
+        public Optional<bool> Mute { get; set; }
 
-        [JsonProperty("deaf", NullValueHandling = NullValueHandling.Ignore)]
-        public bool? Deafen { get; set; }
+        [JsonProperty("deaf")]
+        public Optional<bool> Deafen { get; set; }
 
-        [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Ignore)]
-        public ulong? VoiceChannelId { get; set; }
+        [JsonProperty("channel_id")]
+        public Optional<ulong> VoiceChannelId { get; set; }
     }
 
     internal sealed class RestGuildRolePayload

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1000,7 +1000,9 @@ namespace DSharpPlus.Net
             }
         }
 
-        internal Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, string nick, IEnumerable<ulong> role_ids, bool? mute, bool? deaf, ulong? voice_channel_id, string reason)
+        internal Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, Optional<string> nick,
+            Optional<IEnumerable<ulong>> role_ids, Optional<bool> mute, Optional<bool> deaf,
+            Optional<ulong> voice_channel_id, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
             if (!string.IsNullOrWhiteSpace(reason))

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using DSharpPlus.Net.Abstractions;
+using DSharpPlus.Net.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -132,7 +133,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
             var raw_members = (JArray)json["members"];
@@ -185,7 +186,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
             var raw_members = (JArray)json["members"];
@@ -285,7 +286,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, user_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var tm = JsonConvert.DeserializeObject<TransportMember>(res.Response);
 
@@ -346,7 +347,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld));
         }
 
         internal Task ModifyGuildRolePosition(ulong guild_id, IEnumerable<RestGuildRoleReorderPayload> pld, string reason)
@@ -359,7 +360,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld));
         }
 
         internal async Task<AuditLog> GetAuditLogsAsync(ulong guild_id, int limit, ulong? after, ulong? before, ulong? responsible, int? action_type)
@@ -411,7 +412,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
             ret.Discord = this.Discord;
@@ -445,7 +446,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld));
         }
 
         internal async Task<DiscordChannel> GetChannelAsync(ulong channel_id)
@@ -518,7 +519,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
 
@@ -544,7 +545,7 @@ namespace DSharpPlus.Net
             };
 
             if (!string.IsNullOrEmpty(content) || embed != null || tts == true)
-                values["payload_json"] = JsonConvert.SerializeObject(pld);
+                values["payload_json"] = DiscordJson.SerializeObject(pld);
 
             var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES);
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
@@ -575,7 +576,7 @@ namespace DSharpPlus.Net
                 IsTTS = tts
             };
             if (!string.IsNullOrWhiteSpace(content) || embed != null || tts == true)
-                values["payload_json"] = JsonConvert.SerializeObject(pld);
+                values["payload_json"] = DiscordJson.SerializeObject(pld);
 
             var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES);
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
@@ -664,7 +665,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id, message_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
 
@@ -699,7 +700,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld));
         }
 
         internal async Task<IReadOnlyList<DiscordInvite>> GetChannelInvitesAsync(ulong channel_id)
@@ -733,7 +734,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
             ret.Discord = this.Discord;
@@ -771,7 +772,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, overwrite_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, headers, JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, headers, DiscordJson.SerializeObject(pld));
         }
 
         internal Task TriggerTypingAsync(ulong channel_id)
@@ -829,7 +830,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, user_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, payload: JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, payload: DiscordJson.SerializeObject(pld));
         }
 
         internal Task GroupDmRemoveRecipientAsync(ulong channel_id, ulong user_id)
@@ -853,7 +854,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
             ret.Discord = this.Discord;
@@ -872,7 +873,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
             ret.Discord = this.Discord;
@@ -953,7 +954,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var user_raw = JsonConvert.DeserializeObject<TransportUser>(res.Response);
 
@@ -973,7 +974,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             if (this.Discord is DiscordClient)
             {
@@ -1014,7 +1015,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, user_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, payload: JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, payload: DiscordJson.SerializeObject(pld));
         }
 
         internal Task ModifyCurrentMemberNicknameAsync(ulong guild_id, string nick, string reason)
@@ -1032,7 +1033,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, payload: JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, payload: DiscordJson.SerializeObject(pld));
         }
         #endregion
 
@@ -1095,7 +1096,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, role_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response);
             ret.Discord = this.Discord;
@@ -1136,7 +1137,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response);
             ret.Discord = this.Discord;
@@ -1219,7 +1220,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response);
             ret.Discord = this.Discord;
@@ -1240,7 +1241,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, integration_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response);
             ret.Discord = this.Discord;
@@ -1256,7 +1257,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, integration_id = integration.Id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, payload: JsonConvert.SerializeObject(integration));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, payload: DiscordJson.SerializeObject(integration));
         }
 
         internal Task SyncGuildIntegrationAsync(ulong guild_id, ulong integration_id)
@@ -1289,7 +1290,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: JsonConvert.SerializeObject(embed)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(embed)).ConfigureAwait(false);
 
             var embed_rest = JsonConvert.DeserializeObject<DiscordGuildEmbed>(res.Response);
 
@@ -1422,7 +1423,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
@@ -1506,7 +1507,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { webhook_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
@@ -1531,7 +1532,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { webhook_id, webhook_token }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
@@ -1586,7 +1587,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: JsonConvert.SerializeObject(pld));
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld));
         }
 
         internal Task ExecuteWebhookSlackAsync(ulong webhook_id, string webhook_token, string json_payload)
@@ -1756,7 +1757,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
@@ -1789,7 +1790,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, emoji_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
@@ -1870,7 +1871,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<AcknowledgePayload>(res.Response);
             this.LastAckToken = ret.Token;
@@ -1891,7 +1892,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: JsonConvert.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             if (res.ResponseCode != 204)
             {

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -159,9 +159,12 @@ namespace DSharpPlus.Net
             }
         }
 
-        internal async Task<DiscordGuild> ModifyGuildAsync(ulong guild_id, string name, string region, VerificationLevel? verification_level,
-            DefaultMessageNotifications? default_message_notifications, MfaLevel? mfa_level, ExplicitContentFilter? explicit_content_filter, ulong? afk_channel_id, int? afk_timeout, string iconb64,
-            ulong? owner_id, string splashb64, string reason, bool isSystemChannelSet, ulong? systemChannelId)
+        internal async Task<DiscordGuild> ModifyGuildAsync(ulong guild_id, Optional<string> name,
+            Optional<string> region, Optional<VerificationLevel> verification_level,
+            Optional<DefaultMessageNotifications> default_message_notifications, Optional<MfaLevel> mfa_level,
+            Optional<ExplicitContentFilter> explicit_content_filter, Optional<ulong> afk_channel_id,
+            Optional<int> afk_timeout, Optional<string> iconb64, Optional<ulong> owner_id, Optional<string> splashb64,
+            Optional<ulong?> systemChannelId, string reason)
         {
             var pld = new RestGuildModifyPayload
             {
@@ -176,7 +179,6 @@ namespace DSharpPlus.Net
                 IconBase64 = iconb64,
                 SplashBase64 = splashb64,
                 OwnerId = owner_id,
-                HasSystemChannelId = isSystemChannelSet,
                 SystemChannelId = systemChannelId
             };
             

--- a/DSharpPlus/Net/Models/BaseEditModel.cs
+++ b/DSharpPlus/Net/Models/BaseEditModel.cs
@@ -1,0 +1,7 @@
+﻿namespace DSharpPlus.Net.Models
+{
+    public class BaseEditModel
+    {
+        public string AuditLogReason { internal get; set; }
+    }
+}

--- a/DSharpPlus/Net/Models/ChannelEditModel.cs
+++ b/DSharpPlus/Net/Models/ChannelEditModel.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace DSharpPlus.Net.Models
 {
-    public class ChannelEditModel
+    public class ChannelEditModel : BaseEditModel
     {
         public string Name { internal get; set; }
         public int? Position { internal get; set; }
@@ -15,8 +15,7 @@ namespace DSharpPlus.Net.Models
         public Optional<DiscordChannel> Parent { internal get; set; }
         public int? Bitrate { internal get; set; }
         public int? Userlimit { internal get; set; }
-        public string AuditLogReason { internal get; set; }
-
+        
         internal ChannelEditModel()
         {
 

--- a/DSharpPlus/Net/Models/GuildEditModel.cs
+++ b/DSharpPlus/Net/Models/GuildEditModel.cs
@@ -8,22 +8,21 @@ using System.Threading.Tasks;
 
 namespace DSharpPlus.Net.Models
 {
-    public class GuildEditModel
+    public class GuildEditModel : BaseEditModel
     {
-        public string Name { internal get; set; }
-        public DiscordVoiceRegion Region { internal get; set; }
-        public Stream Icon { internal get; set; }
-        public VerificationLevel VerificationLevel { internal get; set; }
-        public DefaultMessageNotifications DefaultMessageNotifications { internal get; set; }
-        public MfaLevel MfaLevel { internal get; set; }
-        public ExplicitContentFilter ExplicitContentFilter { internal get; set; }
-        public DiscordChannel AfkChannel { internal get; set; }
-        public int? AfkTimeout { internal get; set; }
-        public DiscordMember Owner { internal get; set; }
-        public Stream Splash { internal get; set; }
-        public string AuditLogReason { internal get; set; }
+        public Optional<string> Name { internal get; set; }
+        public Optional<DiscordVoiceRegion> Region { internal get; set; }
+        public Optional<Stream> Icon { internal get; set; }
+        public Optional<VerificationLevel> VerificationLevel { internal get; set; }
+        public Optional<DefaultMessageNotifications> DefaultMessageNotifications { internal get; set; }
+        public Optional<MfaLevel> MfaLevel { internal get; set; }
+        public Optional<ExplicitContentFilter> ExplicitContentFilter { internal get; set; }
+        public Optional<DiscordChannel> AfkChannel { internal get; set; }
+        public Optional<int> AfkTimeout { internal get; set; }
+        public Optional<DiscordMember> Owner { internal get; set; }
+        public Optional<Stream> Splash { internal get; set; }
         public Optional<DiscordChannel> SystemChannel { internal get; set; }
-
+        
         internal GuildEditModel()
         {
 

--- a/DSharpPlus/Net/Models/MemberEditModel.cs
+++ b/DSharpPlus/Net/Models/MemberEditModel.cs
@@ -9,11 +9,11 @@ namespace DSharpPlus.Net.Models
 {
     public class MemberEditModel : BaseEditModel
     {
-        public string Nickname { internal get; set; }
-        public List<DiscordRole> Roles { internal get; set; }
-        public bool? Muted { internal get; set; }
-        public bool? Deafened { internal get; set; }
-        public DiscordChannel VoiceChannel { internal get; set; }
+        public Optional<string> Nickname { internal get; set; }
+        public Optional<List<DiscordRole>> Roles { internal get; set; }
+        public Optional<bool> Muted { internal get; set; }
+        public Optional<bool> Deafened { internal get; set; }
+        public Optional<DiscordChannel> VoiceChannel { internal get; set; }
         
         internal MemberEditModel()
         {

--- a/DSharpPlus/Net/Models/MemberEditModel.cs
+++ b/DSharpPlus/Net/Models/MemberEditModel.cs
@@ -7,15 +7,14 @@ using System.Threading.Tasks;
 
 namespace DSharpPlus.Net.Models
 {
-    public class MemberEditModel
+    public class MemberEditModel : BaseEditModel
     {
         public string Nickname { internal get; set; }
         public List<DiscordRole> Roles { internal get; set; }
         public bool? Muted { internal get; set; }
         public bool? Deafened { internal get; set; }
         public DiscordChannel VoiceChannel { internal get; set; }
-        public string AuditLogReason { internal get; set; }
-
+        
         internal MemberEditModel()
         {
 

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -9,12 +9,14 @@ namespace DSharpPlus.Net.Serialization
 {
     public static class DiscordJson
     {
+        private static readonly OptionalJsonConverter OptionalJsonConverter = new OptionalJsonConverter();
+
         /// <summary>Serializes the specified object to a JSON string.</summary>
         /// <param name="value">The object to serialize.</param>
         /// <returns>A JSON string representation of the object.</returns>
         public static string SerializeObject(object value)
         {
-            return JsonConvert.SerializeObject(value, new OptionalJsonConverter());
+            return JsonConvert.SerializeObject(value, OptionalJsonConverter);
         }
     }
 

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -4,19 +4,59 @@ using System.Reflection;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace DSharpPlus.Net.Serialization
 {
     public static class DiscordJson
     {
-        private static readonly OptionalJsonConverter OptionalJsonConverter = new OptionalJsonConverter();
+        private static readonly JsonConverter[] JsonConverters =
+        {
+            new OptionalJsonConverter()
+        };
+        private static readonly OptionalJsonContractResolver OptionalJsonContractResolver = new OptionalJsonContractResolver();
 
         /// <summary>Serializes the specified object to a JSON string.</summary>
         /// <param name="value">The object to serialize.</param>
         /// <returns>A JSON string representation of the object.</returns>
         public static string SerializeObject(object value)
         {
-            return JsonConvert.SerializeObject(value, OptionalJsonConverter);
+            return JsonConvert.SerializeObject(value, new JsonSerializerSettings
+            {
+                Converters = JsonConverters,
+                ContractResolver = OptionalJsonContractResolver
+            });
+        }
+    }
+
+    public class OptionalJsonContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+
+            var type = property.PropertyType;
+            
+            if (!type.GetTypeInfo().IsGenericType)
+                return property;
+
+            if (type.GetGenericTypeDefinition() != typeof(Optional<>))
+                return property;
+            
+            // we cache the PropertyInfo object here (it's captured in closure). we don't have direct 
+            // access to the property value so we have to reflect into it from the parent instance
+            // we use UnderlyingName instead of PropertyName in case the C# name is different from the Json name.
+            var optionalProp = property.DeclaringType.GetTypeInfo().GetDeclaredProperty(property.UnderlyingName);
+            property.ShouldSerialize = instance => // instance here is the declaring (parent) type
+            {
+                // this is the Optional<T> object
+                var optionalValue = optionalProp.GetValue(instance);
+                // get the HasValue property of the Optional<T> object and cast it to a bool, and only serialize it if
+                // it's present
+                return (bool)optionalValue.GetType().GetTypeInfo().GetDeclaredProperty("HasValue").GetValue(optionalValue);
+            };
+    
+            return property;
         }
     }
 
@@ -25,11 +65,22 @@ namespace DSharpPlus.Net.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var typeInfo = value.GetType().GetTypeInfo();
-            var hasValue = (bool) typeInfo.GetDeclaredProperty("HasValue").GetValue(value);
-
-            if (!hasValue) return;
-            var t = JToken.FromObject(typeInfo.GetDeclaredProperty("Value").GetValue(value));
-            t.WriteTo(writer);
+            // we don't check for HasValue here since it's checked above
+            var val = typeInfo.GetDeclaredProperty("Value").GetValue(value);
+            // JToken.FromObject will throw if `null` so we manually write a null value.
+            if (val == null)
+            {
+                // you can read serializer.NullValueHandling here, but unfortunately you can **not** skip serialization
+                // here, or else you will get a nasty JsonWriterException, so we just ignore its value and manually
+                // write the null.
+                writer.WriteToken(JsonToken.Null);
+            }
+            else
+            {
+                // convert the value to a JSON object and write it to the property value.
+                var t = JToken.FromObject(val);
+                t.WriteTo(writer);
+            }
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
@@ -47,18 +98,5 @@ namespace DSharpPlus.Net.Serialization
 
             return objectType.GetGenericTypeDefinition() == typeof(Optional<>);
         }
-
-//        private static void DisplayTypeInfo(Type t)
-//        {
-//            Console.WriteLine($"\r\n{t}");
-//            Console.WriteLine($"\tIs this a generic type definition? {t.IsGenericTypeDefinition}");
-//            Console.WriteLine($"\tIs it a generic type? {t.IsGenericType}");
-//            var typeArguments = t.GetGenericArguments();
-//            Console.WriteLine($"\tList type arguments ({typeArguments.Length}):");
-//            foreach (var tParam in typeArguments)
-//            {
-//                Console.WriteLine($"\t\t{tParam}");
-//            }
-//        }
     }
 }

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -25,12 +25,10 @@ namespace DSharpPlus.Net.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var typeInfo = value.GetType().GetTypeInfo();
-            var hasValue = (bool) typeInfo.DeclaredProperties.FirstOrDefault(e => e.Name == "HasValue")
-                .GetValue(value);
+            var hasValue = (bool) typeInfo.GetDeclaredProperty("HasValue").GetValue(value);
 
             if (!hasValue) return;
-            var t = JToken.FromObject(typeInfo.DeclaredProperties.FirstOrDefault(e => e.Name == "Value")
-                .GetValue(value));
+            var t = JToken.FromObject(typeInfo.GetDeclaredProperty("Value").GetValue(value));
             t.WriteTo(writer);
         }
 

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -45,13 +45,7 @@ namespace DSharpPlus.Net.Serialization
         {
             if (!objectType.GetTypeInfo().IsGenericType) return false;
 
-            if (objectType.GetGenericTypeDefinition() != typeof(Optional<>)) return false;
-
-            var firstGeneric = objectType.GetTypeInfo().GenericTypeArguments[0];
-
-            if (!firstGeneric.GetTypeInfo().IsGenericType) return false;
-
-            return firstGeneric.GetGenericTypeDefinition() == typeof(Nullable<>);
+            return objectType.GetGenericTypeDefinition() == typeof(Optional<>);
         }
 
 //        private static void DisplayTypeInfo(Type t)

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using DSharpPlus.Entities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DSharpPlus.Net.Serialization
+{
+    public static class DiscordJson
+    {
+        /// <summary>Serializes the specified object to a JSON string.</summary>
+        /// <param name="value">The object to serialize.</param>
+        /// <returns>A JSON string representation of the object.</returns>
+        public static string SerializeObject(object value)
+        {
+            return JsonConvert.SerializeObject(value, new OptionalJsonConverter());
+        }
+    }
+
+    public class OptionalJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var type = value.GetType();
+#if NETSTANDARD1_1 || NETSTANDARD1_3
+            var hasValue = (bool) type.GetTypeInfo().DeclaredProperties.FirstOrDefault(e => e.Name == "HasValue")
+                .GetValue(value);
+#else
+            var hasValue = (bool)type.GetProperty("HasValue").GetValue(value);
+#endif
+
+            if (!hasValue) return;
+
+#if NETSTANDARD1_1 || NETSTANDARD1_3
+            var t = JToken.FromObject(type.GetTypeInfo().DeclaredProperties.FirstOrDefault(e => e.Name == "Value")
+                .GetValue(value));
+#else
+            var t = JToken.FromObject(type.GetProperty("Value").GetValue(value));
+#endif
+            t.WriteTo(writer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            throw new NotImplementedException(
+                "Unnecessary because CanRead is false. The type will skip the converter.");
+        }
+
+        public override bool CanRead => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+#if NETSTANDARD1_1 || NETSTANDARD1_3
+            if (!objectType.GetTypeInfo().IsGenericType) return false;
+#else
+            if (!objectType.IsGenericType) return false;
+#endif
+
+            if (objectType.GetGenericTypeDefinition() != typeof(Optional<>)) return false;
+
+#if NETSTANDARD1_1 || NETSTANDARD1_3
+            var firstGeneric = objectType.GetTypeInfo().GenericTypeArguments[0];
+#else
+            var firstGeneric = objectType.GetGenericArguments()[0];
+#endif
+
+#if NETSTANDARD1_1 || NETSTANDARD1_3
+            if (!firstGeneric.GetTypeInfo().IsGenericType) return false;
+#else
+            if (!firstGeneric.IsGenericType) return false;
+#endif
+
+            return firstGeneric.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
+//        private static void DisplayTypeInfo(Type t)
+//        {
+//            Console.WriteLine($"\r\n{t}");
+//            Console.WriteLine($"\tIs this a generic type definition? {t.IsGenericTypeDefinition}");
+//            Console.WriteLine($"\tIs it a generic type? {t.IsGenericType}");
+//            var typeArguments = t.GetGenericArguments();
+//            Console.WriteLine($"\tList type arguments ({typeArguments.Length}):");
+//            foreach (var tParam in typeArguments)
+//            {
+//                Console.WriteLine($"\t\t{tParam}");
+//            }
+//        }
+    }
+}

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -22,22 +22,13 @@ namespace DSharpPlus.Net.Serialization
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var type = value.GetType();
-#if NETSTANDARD1_1 || NETSTANDARD1_3
-            var hasValue = (bool) type.GetTypeInfo().DeclaredProperties.FirstOrDefault(e => e.Name == "HasValue")
+            var typeInfo = value.GetType().GetTypeInfo();
+            var hasValue = (bool) typeInfo.DeclaredProperties.FirstOrDefault(e => e.Name == "HasValue")
                 .GetValue(value);
-#else
-            var hasValue = (bool)type.GetProperty("HasValue").GetValue(value);
-#endif
 
             if (!hasValue) return;
-
-#if NETSTANDARD1_1 || NETSTANDARD1_3
-            var t = JToken.FromObject(type.GetTypeInfo().DeclaredProperties.FirstOrDefault(e => e.Name == "Value")
+            var t = JToken.FromObject(typeInfo.DeclaredProperties.FirstOrDefault(e => e.Name == "Value")
                 .GetValue(value));
-#else
-            var t = JToken.FromObject(type.GetProperty("Value").GetValue(value));
-#endif
             t.WriteTo(writer);
         }
 
@@ -52,25 +43,13 @@ namespace DSharpPlus.Net.Serialization
 
         public override bool CanConvert(Type objectType)
         {
-#if NETSTANDARD1_1 || NETSTANDARD1_3
             if (!objectType.GetTypeInfo().IsGenericType) return false;
-#else
-            if (!objectType.IsGenericType) return false;
-#endif
 
             if (objectType.GetGenericTypeDefinition() != typeof(Optional<>)) return false;
 
-#if NETSTANDARD1_1 || NETSTANDARD1_3
             var firstGeneric = objectType.GetTypeInfo().GenericTypeArguments[0];
-#else
-            var firstGeneric = objectType.GetGenericArguments()[0];
-#endif
 
-#if NETSTANDARD1_1 || NETSTANDARD1_3
             if (!firstGeneric.GetTypeInfo().IsGenericType) return false;
-#else
-            if (!firstGeneric.IsGenericType) return false;
-#endif
 
             return firstGeneric.GetGenericTypeDefinition() == typeof(Nullable<>);
         }

--- a/DSharpPlus/Properties/AssemblyProperties.cs
+++ b/DSharpPlus/Properties/AssemblyProperties.cs
@@ -9,3 +9,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DSharpPlus.Interactivity")]
 [assembly: InternalsVisibleTo("DSharpPlus.VoiceNext")]
 [assembly: InternalsVisibleTo("DSharpPlus.Rest")]
+
+[assembly: InternalsVisibleTo("DSharpPlus.MSTest")]


### PR DESCRIPTION
# Summary
This is a proof of concept solution for the problem explored in detail in #222, and commented in passing earlier in #165:
![](https://i.imgur.com/iN6QO6d.png)

# Details
It uses a custom JsonConverter for `Optional<T>` (originally just `Optional<Nullable<struct>>`), that only includes the serialized property in the JSON output if the Optional's value is present. With my solution, you can simply use `Optional<struct?>` or `Optional<Nullable<struct>>`. This replaces the original buggy Optional serialization, which would throw an exception if the value was not present.

### Usage
I've created a class, `DSharpPlus.Net.Serialization.DiscordJson` that can be used as a drop-in replacement for `JsonConvert` for calls to `JsonConvert.SerializeObject`.