### PR TITLE
Add DiscordOverwrite.GetMemberAsync and GetRoleAsync

### DIFF
--- a/DSharpPlus/Entities/DiscordOverwrite.cs
+++ b/DSharpPlus/Entities/DiscordOverwrite.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System.Threading.Tasks;
+using System;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/DiscordOverwrite.cs
+++ b/DSharpPlus/Entities/DiscordOverwrite.cs
@@ -56,7 +56,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMember> GetMemberAsync()
         {
             if (this.Type != OverwriteType.Member)
-                throw new ArgumentException(nameof(this.Type), "This overwrite is for a role, not a member");
+                throw new ArgumentException(nameof(this.Type), "This overwrite is for a role, not a member.");
             return await (await this.Discord.ApiClient.GetChannelAsync(this._channel_id)).Guild.GetMemberAsync(this.Id);
         }
 
@@ -67,7 +67,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordRole> GetRoleAsync()
         {
             if (this.Type != OverwriteType.Role)
-                throw new ArgumentException(nameof(this.Type), "This overwrite is for a member, not a role");
+                throw new ArgumentException(nameof(this.Type), "This overwrite is for a member, not a role.");
             return (await this.Discord.ApiClient.GetChannelAsync(this._channel_id)).Guild.GetRole(this.Id);
         }
 

--- a/DSharpPlus/Entities/DiscordOverwrite.cs
+++ b/DSharpPlus/Entities/DiscordOverwrite.cs
@@ -47,6 +47,28 @@ namespace DSharpPlus.Entities
         public Task UpdateAsync(Permissions? allow = null, Permissions? deny = null, string reason = null)
             => this.Discord.ApiClient.EditChannelPermissionsAsync(this._channel_id, this.Id, allow ?? this.Allow, deny ?? this.Deny, this.Type.ToString().ToLowerInvariant(), reason);
         #endregion
+        
+        /// <summary>
+        /// Gets the DiscordMember that is affected by this overwrite.
+        /// </summary>
+        /// <returns>The DiscordMember that is affected by this overwrite</returns>
+        public async Task<DiscordMember> GetMemberAsync()
+        {
+            if (this.Type != OverwriteType.Member)
+                throw new ArgumentException(nameof(this.Type), "This overwrite is for a role, not a member");
+            return await (await this.Discord.ApiClient.GetChannelAsync(this._channel_id)).Guild.GetMemberAsync(this.Id);
+        }
+
+        /// <summary>
+        /// Gets the DiscordRole that is affected by this overwrite.
+        /// </summary>
+        /// <returns>The DiscordRole that is affected by this overwrite</returns>
+        public async Task<DiscordRole> GetRoleAsync()
+        {
+            if (this.Type != OverwriteType.Role)
+                throw new ArgumentException(nameof(this.Type), "This overwrite is for a member, not a role");
+            return await (await this.Discord.ApiClient.GetChannelAsync(this._channel_id)).Guild.GetRole(this.Id);
+        }
 
         internal DiscordOverwrite() { }
 

--- a/DSharpPlus/Entities/DiscordOverwrite.cs
+++ b/DSharpPlus/Entities/DiscordOverwrite.cs
@@ -67,7 +67,7 @@ namespace DSharpPlus.Entities
         {
             if (this.Type != OverwriteType.Role)
                 throw new ArgumentException(nameof(this.Type), "This overwrite is for a member, not a role");
-            return await (await this.Discord.ApiClient.GetChannelAsync(this._channel_id)).Guild.GetRole(this.Id);
+            return (await this.Discord.ApiClient.GetChannelAsync(this._channel_id)).Guild.GetRole(this.Id);
         }
 
         internal DiscordOverwrite() { }


### PR DESCRIPTION
# Summary
Adds convenience methods for getting the Member or Role affected by a permission overwrite.

# Details
The current implementation of these methods is a hack, since DiscordOverwrite does not provide the guild's ID, only the channel ID. This could be changed in future if a new property was to be introduced.

# Changes proposed
* Add DiscordOverwrite.GetMemberAsync
* Add DiscordOverwrite.GetRoleAsync
