### PR TITLE
Changed message history retrieval methods to use IDs instead of message objects

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -946,7 +946,7 @@ namespace DSharpPlus
                     GuildId = channel_new.GuildId,
                     Id = channel_new.Id,
                     //IsPrivate = channel_new.IsPrivate,
-                    LastMessage = channel_new.LastMessage,
+                    LastMessageId = channel_new.LastMessageId,
                     Name = channel_new.Name,
                     _permission_overwrites = new List<DiscordOverwrite>(channel_new._permission_overwrites),
                     Position = channel_new.Position,
@@ -1467,7 +1467,7 @@ namespace DSharpPlus
             if (message.Channel == null)
                 DebugLogger.LogMessage(LogLevel.Warning, "Event", "Could not find channel last message belonged to", DateTime.Now);
             else
-                message.Channel.LastMessage = message;
+                message.Channel.LastMessageId = message.Id;
 
             var guild = message.Channel?.Guild;
 

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -946,7 +946,7 @@ namespace DSharpPlus
                     GuildId = channel_new.GuildId,
                     Id = channel_new.Id,
                     //IsPrivate = channel_new.IsPrivate,
-                    LastMessageId = channel_new.LastMessageId,
+                    LastMessage = channel_new.LastMessage,
                     Name = channel_new.Name,
                     _permission_overwrites = new List<DiscordOverwrite>(channel_new._permission_overwrites),
                     Position = channel_new.Position,
@@ -1467,7 +1467,7 @@ namespace DSharpPlus
             if (message.Channel == null)
                 DebugLogger.LogMessage(LogLevel.Warning, "Event", "Could not find channel last message belonged to", DateTime.Now);
             else
-                message.Channel.LastMessageId = message.Id;
+                message.Channel.LastMessage = message;
 
             var guild = message.Channel?.Guild;
 

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -92,7 +92,7 @@ namespace DSharpPlus.Entities
         public string Topic { get; internal set; } = "";
 
         /// <summary>
-        /// Gets the id of the last message sent in this channel. This is applicable to text channels only.
+        /// Gets the ID of the last message sent in this channel. This is applicable to text channels only.
         /// </summary>
         [JsonProperty("last_message_id", NullValueHandling = NullValueHandling.Ignore)]
         public ulong LastMessageId { get; internal set; } = 0;

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -92,10 +92,10 @@ namespace DSharpPlus.Entities
         public string Topic { get; internal set; } = "";
 
         /// <summary>
-        /// Gets the last message sent in this channel. This is applicable to text channels only.
+        /// Gets the id of the last message sent in this channel. This is applicable to text channels only.
         /// </summary>
-        [JsonProperty("last_message", NullValueHandling = NullValueHandling.Ignore)]
-        public DiscordMessage LastMessage { get; internal set; }
+        [JsonProperty("last_message_id", NullValueHandling = NullValueHandling.Ignore)]
+        public ulong LastMessageId { get; internal set; } = 0;
 
         /// <summary>
         /// Gets this channel's bitrate. This is applicable to voice channels only.
@@ -297,24 +297,24 @@ namespace DSharpPlus.Entities
         /// <param name="limit">The amount of messages to fetch, up to a maximum of 100</param>
         /// <param name="before">Message to fetch before from.</param>
         /// </summary> 
-        public Task<IReadOnlyList<DiscordMessage>> GetMessagesBeforeAsync(DiscordMessage before, int limit = 100)
-            => this._getMessagesAsync(limit, before.Id, null, null);
+        public Task<IReadOnlyList<DiscordMessage>> GetMessagesBeforeAsync(ulong before, int limit = 100)
+            => this._getMessagesAsync(limit, before, null, null);
         
         /// <summary>  
         /// Returns a list of messages after a certain message.
         /// <param name="limit">The amount of messages to fetch, up to a maximum of 100</param>
         /// <param name="after">Message to fetch after from.</param>
         /// </summary> 
-        public Task<IReadOnlyList<DiscordMessage>> GetMessagesAfterAsync(DiscordMessage after, int limit = 100)
-            => this._getMessagesAsync(limit, null, after.Id, null);
+        public Task<IReadOnlyList<DiscordMessage>> GetMessagesAfterAsync(ulong after, int limit = 100)
+            => this._getMessagesAsync(limit, null, after, null);
         
         /// <summary>  
         /// Returns a list of messages around a certain message.
         /// <param name="limit">The amount of messages to fetch, up to a maximum of 100</param>
         /// <param name="around">Message to fetch around from.</param>
         /// </summary> 
-        public Task<IReadOnlyList<DiscordMessage>> GetMessagesAroundAsync(DiscordMessage around, int limit = 100)
-            => this._getMessagesAsync(limit, null, null, around.Id);
+        public Task<IReadOnlyList<DiscordMessage>> GetMessagesAroundAsync(ulong around, int limit = 100)
+            => this._getMessagesAsync(limit, null, null, around);
 
         [System.Obsolete("GetMessagesAsync is deprecated, please use the separate methods instead.")]
         public Task<IReadOnlyList<DiscordMessage>> GetMessagesAsync(int limit = 100, ulong? before = null, ulong? after = null, ulong? around = null) =>

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -92,10 +92,10 @@ namespace DSharpPlus.Entities
         public string Topic { get; internal set; } = "";
 
         /// <summary>
-        /// Gets the ID of the last message sent in this channel. This is applicable to text channels only.
+        /// Gets the last message sent in this channel. This is applicable to text channels only.
         /// </summary>
-        [JsonProperty("last_message_id", NullValueHandling = NullValueHandling.Ignore)]
-        public ulong LastMessageId { get; internal set; } = 0;
+        [JsonProperty("last_message", NullValueHandling = NullValueHandling.Ignore)]
+        public DiscordMessage LastMessage { get; internal set; }
 
         /// <summary>
         /// Gets this channel's bitrate. This is applicable to voice channels only.


### PR DESCRIPTION
# Summary
Changed DiscordChannel.LastMessageId into a DiscordMessage object and renamed to DiscordChannel.LastMessage.

# Details
Proposing a fix for situations like this (now that GetMessagesAsync has been deprecated):
```
await c.GetMessagesBeforeAsync(await c.GetMessageAsync(c.LastMessageId), 5);
```
By changing to a system like this:
```
await c.GetMessagesBeforeAsync(c.LastMessage, 5);
```

This is where `c` is a DiscordChannel, and is not the channel the command has been issued in.

# Changes proposed
* Change LastMessageId into LastMessage (DiscordMessage object)

Pretty simple change, just thought it would simplify these situations.