### PR TITLE
Help

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -697,6 +697,7 @@ namespace DSharpPlus.CommandsNext
                     throw new CommandNotFoundException(string.Join(" ", command));
 
                 helpbuilder.WithCommandName(cmd.Name).WithDescription(cmd.Description);
+                helpbuilder.WithQualifiedCommandName(cmd.QualifiedName);
 
                 if (cmd is CommandGroup g && g.Callable != null)
                     helpbuilder.WithGroupExecutable();

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -699,8 +699,8 @@ namespace DSharpPlus.CommandsNext
                 helpbuilder.WithCommandName(cmd.Name).WithDescription(cmd.Description);
                 helpbuilder.WithQualifiedCommandName(cmd.QualifiedName);
 
-                if (cmd is CommandGroup g && g.Callable != null)
-                    helpbuilder.WithGroupExecutable();
+                if (cmd is CommandGroup g)
+                    helpbuilder.AsCommandGroup(g.Callable != null ? true : false);
 
                 if (cmd.Aliases != null && cmd.Aliases.Any())
                     helpbuilder.WithAliases(cmd.Aliases.OrderBy(xs => xs));

--- a/DSharpPlus.CommandsNext/Converters/BaseHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/BaseHelpFormatter.cs
@@ -65,10 +65,11 @@ namespace DSharpPlus.CommandsNext.Converters
         public abstract BaseHelpFormatter WithSubcommands(IEnumerable<Command> subcommands);
 
         /// <summary>
-        /// When the current command is a group, this sets it as executable.
+        /// This flags the current command as a group, with a bool stating whether or not the group is executable.
         /// </summary>
+        /// <param name="groupExecutable">States whether or not the group is executable.</param>
         /// <returns>Current formatter.</returns>
-        public abstract BaseHelpFormatter WithGroupExecutable();
+        public abstract BaseHelpFormatter AsCommandGroup(bool groupExecutable);
 
         /// <summary>
         /// Construct the help message.

--- a/DSharpPlus.CommandsNext/Converters/BaseHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/BaseHelpFormatter.cs
@@ -30,6 +30,13 @@ namespace DSharpPlus.CommandsNext.Converters
         public abstract BaseHelpFormatter WithCommandName(string name);
 
         /// <summary>
+        /// Gets the full name of the current command, including all module names.
+        /// </summary>
+        /// <param name="name">Qualified name of the command for which the help is displayed.</param>
+        /// <returns>Current formatter.</returns>
+        public abstract BaseHelpFormatter WithQualifiedCommandName(string name);
+
+        /// <summary>
         /// Sets the description of the current command.
         /// </summary>
         /// <param name="description">Description of the command for which help is displayed.</param>

--- a/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
@@ -12,7 +12,7 @@ namespace DSharpPlus.CommandsNext.Converters
     public class DefaultHelpFormatter : BaseHelpFormatter
     {
         private DiscordEmbedBuilder _embed;
-        private string _name, _desc;
+        private string _name, _desc, _qname;
         private bool _gexec;
 
         /// <summary>
@@ -36,6 +36,16 @@ namespace DSharpPlus.CommandsNext.Converters
         public override BaseHelpFormatter WithCommandName(string name)
         {
             this._name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the full name of the current command, including all module names.
+        /// </summary>
+        /// <returns>Current formatter.</returns>
+        public override BaseHelpFormatter WithQualifiedCommandName(string qname)
+        {
+            this._qname = qname;
             return this;
         }
 

--- a/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
@@ -13,7 +13,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         private DiscordEmbedBuilder _embed;
         private string _name, _desc, _qname;
-        private bool _gexec;
+        private bool _g, _gexec;
 
         /// <summary>
         /// Creates a new default help formatter.
@@ -115,12 +115,14 @@ namespace DSharpPlus.CommandsNext.Converters
         }
 
         /// <summary>
-        /// When the current command is a group, this sets it as executable.
+        /// This flags the current command as a group, with a bool stating whether or not the group is executable.
         /// </summary>
+        /// <param name="groupExecutable">Sets whether or not the group is executable.</param>
         /// <returns>Current formatter.</returns>
-        public override BaseHelpFormatter WithGroupExecutable()
+        public override BaseHelpFormatter AsCommandGroup(bool groupExecutable)
         {
-            this._gexec = true;
+            this._gexec = groupExecutable;
+            this._g = true;
             return this;
         }
 

--- a/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
+++ b/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
@@ -16,7 +16,7 @@
     <PackageTags>discord discord-api bots discord-bots chat dsharp dsharpplus csharp dotnet vb-net fsharp commands commandsnext</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46'' Or '$(TargetFramework)' == 'net47'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net47'">
     <PackageReference Include="Emzi0767.Microsoft.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 

--- a/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
+++ b/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>DSharpPlus.CommandsNext</AssemblyName>
     <RootNamespace>DSharpPlus.CommandsNext</RootNamespace>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net45;net46;net47;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,7 +16,7 @@
     <PackageTags>discord discord-api bots discord-bots chat dsharp dsharpplus csharp dotnet vb-net fsharp commands commandsnext</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net47'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46'">
     <PackageReference Include="Emzi0767.Microsoft.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 

--- a/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
+++ b/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
@@ -16,7 +16,7 @@
     <PackageTags>discord discord-api bots discord-bots chat dsharp dsharpplus csharp dotnet vb-net fsharp commands commandsnext</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46'' Or '$(TargetFramework)' == 'net47'">
     <PackageReference Include="Emzi0767.Microsoft.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 

--- a/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
+++ b/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>DSharpPlus.CommandsNext</AssemblyName>
     <RootNamespace>DSharpPlus.CommandsNext</RootNamespace>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net45;net46;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net47;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/DSharpPlus.Test/TestBotHelpFormatter.cs
+++ b/DSharpPlus.Test/TestBotHelpFormatter.cs
@@ -12,7 +12,7 @@ namespace DSharpPlus.Test
         private TestBotService Service { get; }
         
         private string _name = null, _desc = null, _args = null, _aliases = null, _subcs = null, _qname = null;
-        private bool _gexec = false;
+        private bool _g = false, _gexec = false;
 
         public TestBotHelpFormatter(TestBotService dep, CommandsNextExtension cnext)
             : base(cnext)
@@ -38,9 +38,10 @@ namespace DSharpPlus.Test
             return this;
         }
 
-        public override BaseHelpFormatter WithGroupExecutable()
+        public override BaseHelpFormatter AsCommandGroup(bool groupExecutable)
         {
-            this._gexec = true;
+            this._g = true;
+            this._gexec = groupExecutable;
             return this;
         }
 

--- a/DSharpPlus.Test/TestBotHelpFormatter.cs
+++ b/DSharpPlus.Test/TestBotHelpFormatter.cs
@@ -10,8 +10,8 @@ namespace DSharpPlus.Test
     public sealed class TestBotHelpFormatter : BaseHelpFormatter
     {
         private TestBotService Service { get; }
-
-        private string _name = null, _desc = null, _args = null, _aliases = null, _subcs = null;
+        
+        private string _name = null, _desc = null, _args = null, _aliases = null, _subcs = null, _qname = null;
         private bool _gexec = false;
 
         public TestBotHelpFormatter(TestBotService dep, CommandsNextExtension cnext)
@@ -23,6 +23,12 @@ namespace DSharpPlus.Test
         public override BaseHelpFormatter WithCommandName(string name)
         {
             this._name = name;
+            return this;
+        }
+
+        public override BaseHelpFormatter WithQualifiedCommandName(string name)
+        {
+            this._qname = name;
             return this;
         }
 
@@ -80,7 +86,7 @@ namespace DSharpPlus.Test
             }
             else
             {
-                sb.Append(this._name).Append("\n\n");
+                sb.Append(this._qname).Append("\n\n");
 
                 if (this._gexec)
                     sb.Append("This group can be executed as a standalone command.\n\n");


### PR DESCRIPTION
# Summary
Resolves #195 

# Details

- Adds `.WithQualifiedCommandName(string)` method to BaseHelpFormatter, to return all modules in command name.

- Also replaces `.WithGroupExecutable()` with `.AsCommandGroup(bool)` - When called, a bool is set to true, indicating that the command being looked at in the HelpFormatter is a group. The bool passed in the method informs the HelpFormatter whether or not the group is actually Executable.

# Changes proposed
* Did as suggested in issue #195 

# Notes
(Sorry for breaking everything and touching CNext, I got warned not to eek)
  