### PR TITLE
Implement Member.Permissions

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -131,6 +131,12 @@ namespace DSharpPlus.Entities
         public bool IsOwner 
             => this.Id == this.Guild.OwnerId;
 
+        /// <summary>
+        /// Gets this member's permissions in the guild they're part of.
+        /// </summary>
+        [JsonIgnore]
+        public Permissions Permissions => this.Roles.Select(e => e.Permissions).Aggregate((a, b) => a | b);
+
         #region Overriden user properties
         [JsonIgnore]
         internal DiscordUser User 


### PR DESCRIPTION
# Summary
Implements DiscordMember.Permissions.

# Details
Currently, there is no easy way to get a Member's permissions without having a channel. This remedies the issue by adding a property that does the LINQ query the user would otherwise have to do.

# Changes proposed
* Implement DiscordMember.Permissions