### PR TITLE
Use Linq query through String instead of ToCharArray when possible

### DIFF
--- a/DSharpPlus/Entities/DiscordColor.cs
+++ b/DSharpPlus/Entities/DiscordColor.cs
@@ -90,7 +90,11 @@ namespace DSharpPlus.Entities
             else if (color.Length == 7)
                 color = color.Substring(1);
 
+#if !NETSTANDARD1_1
+            if (color.Any(xc => !HexAlphabet.Contains(xc)))
+#else
             if (color.ToCharArray().Any(xc => !HexAlphabet.Contains(xc)))
+#endif
                 throw new ArgumentException(nameof(color), "Colors must consist of hexadecimal characters only.");
 
             this.Value = int.Parse(color, NumberStyles.HexNumber, CultureInfo.InvariantCulture);


### PR DESCRIPTION
# Summary
Uses Linq to query the String directly instead of `ToCharArray()` when not in .NET Standard 1.1, in the `DiscordColor` constructor.

# Details
I noticed you've done the check [here](https://github.com/NaamloosDT/DSharpPlus/blob/master/DSharpPlus.CommandsNext/Attributes/AliasesAttribute.cs#L25-L29) but not in the DiscordColor constructor, so I added it.

# Changes proposed
* Use Linq query through String instead of ToCharArray when possible

# Notes
<3